### PR TITLE
Add command line parser and tier 2 parameter

### DIFF
--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -1,0 +1,24 @@
+using System;
+using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
+using System.Linq;
+
+namespace Unit4.Automation
+{
+    internal class BcrFilter : IBcrMiddleware
+    {
+        private readonly BcrOptions _options;
+
+        public BcrFilter(BcrOptions options)
+        {
+            _options = options;
+        }
+
+        public Bcr Use(Bcr bcr)
+        {
+            var newBcr = new Bcr();
+            newBcr.Lines = _options.Tier2 == null ? bcr.Lines.ToList() : bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList();
+            return newBcr;
+        }
+    }
+}

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -16,9 +16,12 @@ namespace Unit4.Automation
 
         public Bcr Use(Bcr bcr)
         {
-            var newBcr = new Bcr();
-            newBcr.Lines = _options.Tier2 == null ? bcr.Lines.ToList() : bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList();
-            return newBcr;
+            if (_options.Tier2 == null)
+            {
+                return bcr;
+            }
+
+            return new Bcr(bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList());
         }
     }
 }

--- a/Unit4/BcrReader.cs
+++ b/Unit4/BcrReader.cs
@@ -12,7 +12,7 @@ using Unit4.Automation.Model;
 
 namespace Unit4.Automation
 {
-    internal class BcrReader
+    internal class BcrReader : IBcrReader
     {
         private readonly ILogging _log;
         private readonly CostCentreHierarchy _hierarchy;

--- a/Unit4/BcrReader.cs
+++ b/Unit4/BcrReader.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Data;
+using System.Diagnostics;
+using System.Collections.Concurrent;
+using Unit4.Automation.Interfaces;
+using Unit4.Automation.ReportEngine;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation
+{
+    internal class BcrReader
+    {
+        private readonly ILogging _log;
+        private readonly CostCentreHierarchy _hierarchy;
+
+        public BcrReader(ILogging log)
+        {
+            _log = log;
+
+            var costCentreList = 
+                new Cache<SerializableCostCentreList>(
+                        () => new CostCentresProvider().GetCostCentres(), 
+                        new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")));
+            _hierarchy = new CostCentreHierarchy(costCentreList);
+        }
+
+        public Bcr Read()
+        {
+            var tier3Hierarchy = _hierarchy.GetHierarchyByTier3();
+
+            var factory = new Unit4EngineFactory();
+            var bcrReport = 
+                new Cache<Bcr>(
+                    () => new BcrReport(factory, _log).RunBCR(tier3Hierarchy), 
+                    new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")));
+
+            return bcrReport.Fetch();
+        }
+    }
+}

--- a/Unit4/BcrReport.cs
+++ b/Unit4/BcrReport.cs
@@ -29,7 +29,7 @@ namespace Unit4.Automation
         {
             var reportsToRun = hierarchy.Select(x => new Report() { Tier = Tier.Tier3, Hierarchy = x });
             
-            return new Bcr() { Lines = RunBCR(reportsToRun).ToList() };
+            return new Bcr(RunBCR(reportsToRun).ToList());
         }
 
         private IEnumerable<BcrLine> RunBCR(IEnumerable<Report> reports)

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -12,13 +12,13 @@ using Unit4.Automation.Model;
 
 namespace Unit4.Automation
 {
-    internal class ReportRunner : IRunner
+    internal class BcrReportRunner : IRunner
     {
         private readonly ILogging _log;
         private readonly BcrLineBuilder _builder;
         private readonly CostCentreHierarchy _hierarchy;
 
-        public ReportRunner()
+        public BcrReportRunner()
         {
             _log = new Logging();
             _builder = new BcrLineBuilder();

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -15,8 +15,8 @@ namespace Unit4.Automation
     internal class BcrReportRunner : IRunner
     {
         private readonly ILogging _log;
-        private readonly BcrReader _reader;
-        private readonly Excel _writer;
+        private readonly IBcrReader _reader;
+        private readonly IBcrWriter _writer;
 
         public BcrReportRunner()
         {
@@ -43,7 +43,7 @@ namespace Unit4.Automation
 
                     progress.Update("Writing to Excel");
 
-                    _writer.WriteToExcel(outputPath, bcr);
+                    _writer.Write(outputPath, bcr);
 
                     progress.Complete();
                 }

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -15,10 +15,14 @@ namespace Unit4.Automation
     internal class BcrReportRunner : IRunner
     {
         private readonly ILogging _log;
+        private readonly BcrReader _reader;
+        private readonly Excel _writer;
 
         public BcrReportRunner()
         {
             _log = new Logging();
+            _reader = new BcrReader(_log);
+            _writer = new Excel();
         }
 
         public void Run()
@@ -33,13 +37,13 @@ namespace Unit4.Automation
                 {
                     progress.Update("Getting BCRs");
 
-                    var bcr = new BcrReader(_log).Read();
+                    var bcr = _reader.Read();
 
                     progress.Complete();
 
                     progress.Update("Writing to Excel");
 
-                    new Excel().WriteToExcel(outputPath, bcr);
+                    _writer.WriteToExcel(outputPath, bcr);
 
                     progress.Complete();
                 }

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -16,13 +16,15 @@ namespace Unit4.Automation
     {
         private readonly ILogging _log;
         private readonly IBcrReader _reader;
+        private readonly IBcrMiddleware _middleware;
         private readonly IBcrWriter _writer;
 
-        public BcrReportRunner()
+        public BcrReportRunner(ILogging log, IBcrReader reader, IBcrMiddleware middleware, IBcrWriter writer)
         {
-            _log = new Logging();
-            _reader = new BcrReader(_log);
-            _writer = new Excel();
+            _log = log;
+            _reader = reader;
+            _middleware = middleware;
+            _writer = writer;
         }
 
         public void Run()

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -43,6 +43,8 @@ namespace Unit4.Automation
 
                     progress.Complete();
 
+                    _middleware.Use(bcr);
+                    
                     progress.Update("Writing to Excel");
 
                     _writer.Write(outputPath, bcr);

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -43,11 +43,11 @@ namespace Unit4.Automation
 
                     progress.Complete();
 
-                    _middleware.Use(bcr);
-                    
+                    var finalBcr = _middleware.Use(bcr);
+
                     progress.Update("Writing to Excel");
 
-                    _writer.Write(outputPath, bcr);
+                    _writer.Write(outputPath, finalBcr);
 
                     progress.Complete();
                 }

--- a/Unit4/BcrReportRunner.cs
+++ b/Unit4/BcrReportRunner.cs
@@ -15,19 +15,10 @@ namespace Unit4.Automation
     internal class BcrReportRunner : IRunner
     {
         private readonly ILogging _log;
-        private readonly BcrLineBuilder _builder;
-        private readonly CostCentreHierarchy _hierarchy;
 
         public BcrReportRunner()
         {
             _log = new Logging();
-            _builder = new BcrLineBuilder();
-
-            var costCentreList = 
-                new Cache<SerializableCostCentreList>(
-                        () => new CostCentresProvider().GetCostCentres(), 
-                        new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")));
-            _hierarchy = new CostCentreHierarchy(costCentreList);
         }
 
         public void Run()
@@ -40,23 +31,9 @@ namespace Unit4.Automation
                 stopwatch.Start();
                 long elapsed = 0, current = 0;
 
-                Console.WriteLine("Getting cost centre hierarchy");
-
-                var tier3Hierarchy = _hierarchy.GetHierarchyByTier3();
-
-                current = stopwatch.ElapsedMilliseconds;
-                Console.WriteLine(string.Format("Elapsed: {0}ms", current - elapsed));
-                elapsed = current;
-
                 Console.WriteLine("Getting BCRs");
 
-                var factory = new Unit4EngineFactory();
-                var bcrReport = 
-                    new Cache<Bcr>(
-                        () => new BcrReport(factory, _log).RunBCR(tier3Hierarchy), 
-                        new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")));
-
-                var bcr = bcrReport.Fetch();
+                var bcr = new BcrReader(_log).Read();
 
                 current = stopwatch.ElapsedMilliseconds;
                 Console.WriteLine(string.Format("Elapsed: {0}ms", current - elapsed));

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -9,7 +9,6 @@ namespace Unit4.Automation
 {
     internal class CommandParser<TVerb> where TVerb : IOptions
     {
-        public enum Command { Help, Bcr };
         private readonly Parser _parser;
 
         public CommandParser(TextWriter output)

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -26,7 +26,7 @@ namespace Unit4.Automation
         }
     }
 
-    [Verb("bcr")]
+    [Verb("bcr", HelpText = "Produce a BCR.")]
     internal class BcrOptions
     {
 

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -16,6 +16,7 @@ namespace Unit4.Automation
             _parser = new Parser(settings => {
                 settings.CaseSensitive = false;
                 settings.HelpWriter = output;
+                settings.MaximumDisplayWidth = Console.WindowWidth > 0 ? Console.WindowWidth : 80; //workaround for tests in Travis
             });
         }
 

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.IO;
 using CommandLine;
+using Unit4.Automation.Interfaces;
+using Unit4.Automation.Model;
 
 namespace Unit4.Automation
 {
@@ -18,17 +20,11 @@ namespace Unit4.Automation
             });
         }
 
-        public Command GetCommand(params string[] args)
+        public IOptions GetCommand(params string[] args)
         {
             return _parser
                 .ParseArguments(args, typeof(BcrOptions))
-                .MapResult<BcrOptions, Command>(options => Command.Bcr, errors => Command.Help);
+                .MapResult<BcrOptions, IOptions>(options => options, errors => new NullOptions());
         }
-    }
-
-    [Verb("bcr", HelpText = "Produce a BCR.")]
-    internal class BcrOptions
-    {
-
     }
 }

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -7,7 +7,7 @@ using Unit4.Automation.Model;
 
 namespace Unit4.Automation
 {
-    internal class CommandParser
+    internal class CommandParser<TVerb> where TVerb : IOptions
     {
         public enum Command { Help, Bcr };
         private readonly Parser _parser;
@@ -23,8 +23,8 @@ namespace Unit4.Automation
         public IOptions GetCommand(params string[] args)
         {
             return _parser
-                .ParseArguments(args, typeof(BcrOptions))
-                .MapResult<BcrOptions, IOptions>(options => options, errors => new NullOptions());
+                .ParseArguments(args, typeof(TVerb))
+                .MapResult<TVerb, IOptions>(options => options, errors => new NullOptions());
         }
     }
 }

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.IO;
 using CommandLine;
 
 namespace Unit4.Automation
@@ -7,11 +8,19 @@ namespace Unit4.Automation
     internal class CommandParser
     {
         public enum Command { Help, Bcr };
+        private readonly Parser _parser;
+
+        public CommandParser(TextWriter output)
+        {
+            _parser = new Parser(settings => {
+                settings.CaseSensitive = false;
+                settings.HelpWriter = output;
+            });
+        }
 
         public Command GetCommand(params string[] args)
         {
-            var parser = new Parser(settings => settings.CaseSensitive = false);
-            return parser
+            return _parser
                 .ParseArguments(args, typeof(BcrOptions))
                 .MapResult<BcrOptions, Command>(options => Command.Bcr, errors => Command.Help);
         }

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -19,7 +19,7 @@ namespace Unit4.Automation
             });
         }
 
-        public IOptions GetCommand(params string[] args)
+        public IOptions GetOptions(params string[] args)
         {
             return _parser
                 .ParseArguments(args, typeof(TVerb))

--- a/Unit4/CommandParser.cs
+++ b/Unit4/CommandParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using CommandLine;
 
 namespace Unit4.Automation
 {
@@ -9,16 +10,16 @@ namespace Unit4.Automation
 
         public Command GetCommand(params string[] args)
         {
-            if (!args.Any())
-            {
-                return Command.Help;
-            }
-
-            switch (args.First().ToLowerInvariant())
-            {
-                case "bcr": return Command.Bcr;
-                default:    return Command.Help;
-            }
+            var parser = new Parser(settings => settings.CaseSensitive = false);
+            return parser
+                .ParseArguments(args, typeof(BcrOptions))
+                .MapResult<BcrOptions, Command>(options => Command.Bcr, errors => Command.Help);
         }
+    }
+
+    [Verb("bcr")]
+    internal class BcrOptions
+    {
+
     }
 }

--- a/Unit4/Excel.cs
+++ b/Unit4/Excel.cs
@@ -5,12 +5,13 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
 using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
 
 namespace Unit4.Automation
 {
-    internal class Excel
+    internal class Excel : IBcrWriter
     {
-        public void WriteToExcel(string path, Bcr bcr)
+        public void Write(string path, Bcr bcr)
         {
             var app = new MSExcel.Application();
             var workbook = app.Workbooks.Add();

--- a/Unit4/Interfaces/IBcrMiddleware.cs
+++ b/Unit4/Interfaces/IBcrMiddleware.cs
@@ -1,0 +1,10 @@
+using System;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Interfaces
+{
+    internal interface IBcrMiddleware
+    {
+        Bcr Use(Bcr bcr);
+    }
+}

--- a/Unit4/Interfaces/IBcrReader.cs
+++ b/Unit4/Interfaces/IBcrReader.cs
@@ -1,0 +1,10 @@
+using System;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Interfaces
+{
+    internal interface IBcrReader
+    {
+        Bcr Read();
+    }
+}

--- a/Unit4/Interfaces/IBcrWriter.cs
+++ b/Unit4/Interfaces/IBcrWriter.cs
@@ -1,0 +1,10 @@
+using System;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Interfaces
+{
+    internal interface IBcrWriter
+    {
+        void Write(string path, Bcr bcr);
+    }
+}

--- a/Unit4/Interfaces/IOptions.cs
+++ b/Unit4/Interfaces/IOptions.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Unit4.Automation.Interfaces
+{
+    internal interface IOptions
+    {
+    }
+}

--- a/Unit4/Interfaces/IRunner.cs
+++ b/Unit4/Interfaces/IRunner.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Unit4.Automation.Interfaces
+{
+    internal interface IRunner
+    {
+        void Run();
+    }
+}

--- a/Unit4/Model/Bcr.cs
+++ b/Unit4/Model/Bcr.cs
@@ -6,17 +6,25 @@ namespace Unit4.Automation.Model
 {
     internal class Bcr
     {
-        private IEnumerable<BcrLine> _lines;
+        private readonly IEnumerable<BcrLine> _lines;
+
+        public Bcr(IEnumerable<BcrLine> lines)
+        {
+            if (lines == null)
+            {
+                _lines = Enumerable.Empty<BcrLine>();
+            }
+            else
+            {
+                _lines = lines;
+            }
+        }
 
         public IEnumerable<BcrLine> Lines
         {
             get
             {
-                return _lines == null ? Enumerable.Empty<BcrLine>() : _lines;
-            }
-            set
-            {
-                _lines = value;
+                return _lines;
             }
         }
     }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -9,5 +9,15 @@ namespace Unit4.Automation.Model
     [Verb("bcr", HelpText = "Produce a BCR.")]
     internal class BcrOptions : IOptions
     {
+        public BcrOptions() : this(null)
+        {}
+
+        public BcrOptions(string tier2)
+        {
+
+        }
+
+        [Option(HelpText = "Filter by a tier 2 code.")]
+        public string Tier2 { get { throw new NotImplementedException(); } }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -9,15 +9,17 @@ namespace Unit4.Automation.Model
     [Verb("bcr", HelpText = "Produce a BCR.")]
     internal class BcrOptions : IOptions
     {
+        private readonly string _tier2;
+
         public BcrOptions() : this(null)
         {}
 
         public BcrOptions(string tier2)
         {
-
+            _tier2 = tier2;
         }
 
         [Option(HelpText = "Filter by a tier 2 code.")]
-        public string Tier2 { get { throw new NotImplementedException(); } }
+        public string Tier2 { get { return _tier2; } }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unit4.Automation.Interfaces;
+using CommandLine;
+
+namespace Unit4.Automation.Model
+{
+    [Verb("bcr", HelpText = "Produce a BCR.")]
+    internal class BcrOptions : IOptions
+    {
+    }
+}

--- a/Unit4/Model/NullOptions.cs
+++ b/Unit4/Model/NullOptions.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unit4.Automation.Interfaces;
+
+namespace Unit4.Automation.Model
+{
+    internal class NullOptions : IOptions
+    {
+    }
+}

--- a/Unit4/NullRunner.cs
+++ b/Unit4/NullRunner.cs
@@ -1,0 +1,11 @@
+using System;
+using Unit4.Automation.Interfaces;
+
+namespace Unit4.Automation
+{
+    internal class NullRunner : IRunner
+    {
+        public void Run()
+        {}
+    }
+}

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Unit4.Automation.Model;
 using Command = Unit4.Automation.CommandParser.Command;
 
 namespace Unit4.Automation
@@ -10,15 +11,13 @@ namespace Unit4.Automation
         {
             var command = new CommandParser(Console.Out).GetCommand(args);
 
-            switch (command)
+            if (command.GetType() == typeof(BcrOptions))
             {
-                case Command.Bcr:
-                    new ReportRunner().Run();
-                    break;
-                case Command.Help:
-                default:
-                    Help();
-                    break;
+                new ReportRunner().Run();
+            }
+            else
+            {
+                Help();
             }
         }
 

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -8,9 +8,9 @@ namespace Unit4.Automation
     {
         static void Main(string[] args)
         {
-            var command = new CommandParser<BcrOptions>(Console.Out).GetCommand(args);
+            var options = new CommandParser<BcrOptions>(Console.Out).GetOptions(args);
 
-            var runner = new ReportRunnerFactory().Create(command);
+            var runner = new ReportRunnerFactory().Create(options);
 
             runner.Run();
         }

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -10,11 +10,9 @@ namespace Unit4.Automation
         {
             var command = new CommandParser<BcrOptions>(Console.Out).GetCommand(args);
 
-            var bcrOptions = command as BcrOptions;
-            if (bcrOptions != null)
-            {
-                new ReportRunner().Run();
-            }
+            var runner = new ReportRunnerFactory().Create(command);
+
+            runner.Run();
         }
     }
 }

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Unit4.Automation.Model;
-using Command = Unit4.Automation.CommandParser<Unit4.Automation.Model.BcrOptions>.Command;
 
 namespace Unit4.Automation
 {
@@ -15,19 +14,6 @@ namespace Unit4.Automation
             {
                 new ReportRunner().Run();
             }
-            else
-            {
-                Help();
-            }
-        }
-
-        private static void Help()
-        {
-            var commands = Enum.GetNames(typeof(Command)).Select(x => x.ToLowerInvariant()).ToArray();
-            Console.WriteLine(string.Format(@"Unit4 Automation
-
-Available commands:
-{0}", string.Join(Environment.NewLine, commands)));
         }
     }
 }

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -8,7 +8,7 @@ namespace Unit4.Automation
     {
         static void Main(string[] args)
         {
-            var command = new CommandParser().GetCommand(args);
+            var command = new CommandParser(Console.Out).GetCommand(args);
 
             switch (command)
             {

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Unit4.Automation.Model;
-using Command = Unit4.Automation.CommandParser.Command;
+using Command = Unit4.Automation.CommandParser<Unit4.Automation.Model.BcrOptions>.Command;
 
 namespace Unit4.Automation
 {
@@ -9,7 +9,7 @@ namespace Unit4.Automation
     {
         static void Main(string[] args)
         {
-            var command = new CommandParser(Console.Out).GetCommand(args);
+            var command = new CommandParser<BcrOptions>(Console.Out).GetCommand(args);
 
             if (command.GetType() == typeof(BcrOptions))
             {

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -10,7 +10,8 @@ namespace Unit4.Automation
         {
             var command = new CommandParser<BcrOptions>(Console.Out).GetCommand(args);
 
-            if (command.GetType() == typeof(BcrOptions))
+            var bcrOptions = command as BcrOptions;
+            if (bcrOptions != null)
             {
                 new ReportRunner().Run();
             }

--- a/Unit4/ReportRunner.cs
+++ b/Unit4/ReportRunner.cs
@@ -12,7 +12,7 @@ using Unit4.Automation.Model;
 
 namespace Unit4.Automation
 {
-    internal class ReportRunner
+    internal class ReportRunner : IRunner
     {
         private readonly ILogging _log;
         private readonly BcrLineBuilder _builder;

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -14,19 +14,12 @@ namespace Unit4.Automation
             {
                 var log = new Logging();
                 var reader = new BcrReader(log);
+                var filter = new BcrFilter(bcrOptions);
                 var writer = new Excel();
-                return new BcrReportRunner(log, reader, new NullMiddleware(), writer);
+                return new BcrReportRunner(log, reader, filter, writer);
             }
 
             return new NullRunner();
-        }
-    }
-
-    internal class NullMiddleware : IBcrMiddleware
-    {
-        public Bcr Use(Bcr bcr)
-        {
-            return bcr;
         }
     }
 }

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
+using Unit4.Automation.ReportEngine;
 
 namespace Unit4.Automation
 {
@@ -11,10 +12,21 @@ namespace Unit4.Automation
             var bcrOptions = options as BcrOptions;
             if (bcrOptions != null)
             {
-                return new BcrReportRunner();
+                var log = new Logging();
+                var reader = new BcrReader(log);
+                var writer = new Excel();
+                return new BcrReportRunner(log, reader, new NullMiddleware(), writer);
             }
 
             return new NullRunner();
+        }
+    }
+
+    internal class NullMiddleware : IBcrMiddleware
+    {
+        public Bcr Use(Bcr bcr)
+        {
+            return bcr;
         }
     }
 }

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -1,0 +1,20 @@
+using System;
+using Unit4.Automation.Interfaces;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation
+{
+    internal class ReportRunnerFactory
+    {
+        public IRunner Create(IOptions options)
+        {
+            var bcrOptions = options as BcrOptions;
+            if (bcrOptions != null)
+            {
+                return new ReportRunner();
+            }
+
+            return new NullRunner();
+        }
+    }
+}

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -11,7 +11,7 @@ namespace Unit4.Automation
             var bcrOptions = options as BcrOptions;
             if (bcrOptions != null)
             {
-                return new ReportRunner();
+                return new BcrReportRunner();
             }
 
             return new NullRunner();

--- a/Unit4/Resql.cs
+++ b/Unit4/Resql.cs
@@ -23,7 +23,7 @@ namespace Unit4.Automation
 .declare [Budget Group (Tier4)] String ''
 
 .query [GL-COA-001 Revenue Cost Centre Hierarchy Report] 
-    agr_getBrowser 'GL-COA-001 Revenue Cost Centre Hierarchy Report', dim_value_eq='$?[Cost Centre]', client_eq='$?[Company]', r0r0r0r1dim_value_eq='$?[Directorate]', r0r0r1dim_value_eq='$?[Service Group (Tier2)]', r0r1dim_value_eq='$?[Service (Tier3)]', r1dim_value_eq='$?[Budget Group (Tier4)]'
+    agr_getBrowser 'GL-COA-001 Revenue Cost Centre Hierarchy Report', dim_value_eq='$?[Cost Centre]', client_eq='$?[Company]', r0r0r0r1dim_value_eq='$?[Directorate]', r0r0r1dim_value_eq='$?[Service Group (Tier2)]', r0r1dim_value_eq='$?[Service (Tier3)]', r1dim_value_eq='$?[Budget Group (Tier4)]', status_eq='N'
 .endQuery";
             }
         }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -67,21 +67,4 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines, Has.Count.EqualTo(1));
         }
     }
-
-    internal class BcrFilter : IBcrMiddleware
-    {
-        private readonly BcrOptions _options;
-
-        public BcrFilter(BcrOptions options)
-        {
-            _options = options;
-        }
-
-        public Bcr Use(Bcr bcr)
-        {
-            var newBcr = new Bcr();
-            newBcr.Lines = _options.Tier2 == null ? bcr.Lines.ToList() : bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList();
-            return newBcr;
-        }
-    }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -3,6 +3,7 @@ using Unit4.Automation;
 using NUnit.Framework;
 using Unit4.Automation.Model;
 using Unit4.Automation.Interfaces;
+using System.Linq;
 
 namespace Unit4.Automation.Tests
 {
@@ -50,14 +51,18 @@ namespace Unit4.Automation.Tests
 
     internal class BcrFilter : IBcrMiddleware
     {
+        private readonly BcrOptions _options;
+
         public BcrFilter(BcrOptions options)
         {
-
+            _options = options;
         }
 
         public Bcr Use(Bcr bcr)
         {
-            throw new NotImplementedException();
+            var newBcr = new Bcr();
+            newBcr.Lines = bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList();
+            return newBcr;
         }
     }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Unit4.Automation;
+using NUnit.Framework;
+using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    public class BcrFilterTests
+    {
+        [Test]
+        public void GivenTier2Option_ThenLinesNotMatchingThatTier2ShouldNotBeIncluded()
+        {
+            var options = new BcrOptions("tier2");
+
+            var filter = new BcrFilter(options);
+
+            var bcr = new Bcr();
+            bcr.Lines = new BcrLine[] {
+                    new BcrLine() {
+                        CostCentre = new CostCentre() {
+                            Tier2 = "notTheRightTier2"
+                        }
+                    },
+                };
+
+            Assert.That(filter.Use(bcr).Lines, Is.Empty);
+        }
+    }
+
+    internal class BcrFilter : IBcrMiddleware
+    {
+        public BcrFilter(BcrOptions options)
+        {
+
+        }
+
+        public Bcr Use(Bcr bcr)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -80,7 +80,7 @@ namespace Unit4.Automation.Tests
         public Bcr Use(Bcr bcr)
         {
             var newBcr = new Bcr();
-            newBcr.Lines = bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList();
+            newBcr.Lines = _options.Tier2 == null ? bcr.Lines.ToList() : bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList();
             return newBcr;
         }
     }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -47,6 +47,25 @@ namespace Unit4.Automation.Tests
 
             Assert.That(filter.Use(bcr).Lines, Has.Count.EqualTo(1));
         }
+
+        [Test]
+        public void GivenNoTier2Option_ThenAllLinesShouldBeIncluded()
+        {
+            var options = new BcrOptions();
+
+            var filter = new BcrFilter(options);
+
+            var bcr = new Bcr();
+            bcr.Lines = new BcrLine[] {
+                    new BcrLine() {
+                        CostCentre = new CostCentre() {
+                            Tier2 = "tier2"
+                        }
+                    },
+                };
+
+            Assert.That(filter.Use(bcr).Lines, Has.Count.EqualTo(1));
+        }
     }
 
     internal class BcrFilter : IBcrMiddleware

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -17,14 +17,13 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr();
-            bcr.Lines = new BcrLine[] {
+            var bcr = new Bcr(new BcrLine[] {
                     new BcrLine() {
                         CostCentre = new CostCentre() {
                             Tier2 = "notTheRightTier2"
                         }
                     },
-                };
+                });
 
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
@@ -36,16 +35,15 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr();
-            bcr.Lines = new BcrLine[] {
+            var bcr = new Bcr(new BcrLine[] {
                     new BcrLine() {
                         CostCentre = new CostCentre() {
                             Tier2 = "tier2"
                         }
                     },
-                };
+                });
 
-            Assert.That(filter.Use(bcr).Lines, Has.Count.EqualTo(1));
+            Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -55,16 +53,15 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr();
-            bcr.Lines = new BcrLine[] {
+            var bcr = new Bcr(new BcrLine[] {
                     new BcrLine() {
                         CostCentre = new CostCentre() {
                             Tier2 = "tier2"
                         }
                     },
-                };
+                });
 
-            Assert.That(filter.Use(bcr).Lines, Has.Count.EqualTo(1));
+            Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
     }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -27,6 +27,25 @@ namespace Unit4.Automation.Tests
 
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
+
+        [Test]
+        public void GivenTier2Option_ThenLinesMatchingThatTier2ShouldBeIncluded()
+        {
+            var options = new BcrOptions("tier2");
+
+            var filter = new BcrFilter(options);
+
+            var bcr = new Bcr();
+            bcr.Lines = new BcrLine[] {
+                    new BcrLine() {
+                        CostCentre = new CostCentre() {
+                            Tier2 = "tier2"
+                        }
+                    },
+                };
+
+            Assert.That(filter.Use(bcr).Lines, Has.Count.EqualTo(1));
+        }
     }
 
     internal class BcrFilter : IBcrMiddleware

--- a/Unit4/Tests/BcrReportRunnerTests.cs
+++ b/Unit4/Tests/BcrReportRunnerTests.cs
@@ -4,6 +4,7 @@ using Unit4.Automation.Interfaces;
 using NUnit.Framework;
 using Moq;
 using System.IO;
+using System.Linq;
 
 namespace Unit4.Automation.Tests
 {
@@ -16,7 +17,7 @@ namespace Unit4.Automation.Tests
             var log = Mock.Of<ILogging>();
             var writer = Mock.Of<IBcrWriter>();
 
-            var bcr = new Bcr();
+            var bcr = new Bcr(Enumerable.Empty<BcrLine>());
 
             var reader = new Mock<IBcrReader>();
             reader.Setup(x => x.Read()).Returns(bcr);
@@ -36,7 +37,7 @@ namespace Unit4.Automation.Tests
             var log = Mock.Of<ILogging>();
             var reader = Mock.Of<IBcrReader>();
 
-            var bcr = new Bcr();
+            var bcr = new Bcr(Enumerable.Empty<BcrLine>());
 
             var middleware = new Mock<IBcrMiddleware>();
             middleware.Setup(x => x.Use(It.IsAny<Bcr>())).Returns(bcr);

--- a/Unit4/Tests/BcrReportRunnerTests.cs
+++ b/Unit4/Tests/BcrReportRunnerTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
+using NUnit.Framework;
+using Moq;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    public class BcrReportRunnerTests
+    {
+        [Test]
+        public void GivenBcrFromReader_ThenThatBcrShouldBePassedToTheMiddleware()
+        {
+            var log = Mock.Of<ILogging>();
+            var writer = Mock.Of<IBcrWriter>();
+
+            var bcr = new Bcr();
+
+            var reader = new Mock<IBcrReader>();
+            reader.Setup(x => x.Read()).Returns(bcr);
+
+            var middleware = new Mock<IBcrMiddleware>();
+
+            var runner = new BcrReportRunner(log, reader.Object, middleware.Object, writer);
+
+            runner.Run();
+
+            middleware.Verify(x => x.Use(bcr), Times.Once);
+        }
+    }
+}

--- a/Unit4/Tests/BcrReportRunnerTests.cs
+++ b/Unit4/Tests/BcrReportRunnerTests.cs
@@ -28,5 +28,25 @@ namespace Unit4.Automation.Tests
 
             middleware.Verify(x => x.Use(bcr), Times.Once);
         }
+
+        [Test]
+        public void GivenBcrFromMiddleware_ThenThatBcrShouldBePassedToTheWriter()
+        {
+            var log = Mock.Of<ILogging>();
+            var reader = Mock.Of<IBcrReader>();
+
+            var bcr = new Bcr();
+
+            var middleware = new Mock<IBcrMiddleware>();
+            middleware.Setup(x => x.Use(It.IsAny<Bcr>())).Returns(bcr);
+
+            var writer = new Mock<IBcrWriter>();
+
+            var runner = new BcrReportRunner(log, reader, middleware.Object, writer.Object);
+
+            runner.Run();
+
+            writer.Verify(x => x.Write(It.IsAny<string>(), bcr), Times.Once);
+        }
     }
 }

--- a/Unit4/Tests/BcrReportRunnerTests.cs
+++ b/Unit4/Tests/BcrReportRunnerTests.cs
@@ -3,6 +3,7 @@ using Unit4.Automation.Model;
 using Unit4.Automation.Interfaces;
 using NUnit.Framework;
 using Moq;
+using System.IO;
 
 namespace Unit4.Automation.Tests
 {
@@ -22,7 +23,7 @@ namespace Unit4.Automation.Tests
 
             var middleware = new Mock<IBcrMiddleware>();
 
-            var runner = new BcrReportRunner(log, reader.Object, middleware.Object, writer);
+            var runner = new BcrReportRunner(log, reader.Object, middleware.Object, writer, TextWriter.Null);
 
             runner.Run();
 
@@ -42,7 +43,7 @@ namespace Unit4.Automation.Tests
 
             var writer = new Mock<IBcrWriter>();
 
-            var runner = new BcrReportRunner(log, reader, middleware.Object, writer.Object);
+            var runner = new BcrReportRunner(log, reader, middleware.Object, writer.Object, TextWriter.Null);
 
             runner.Run();
 

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -20,25 +20,25 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenNoArguments_ThenTheCommandShouldBeHelp()
         {
-            Assert.That(_parser.GetCommand(), Is.TypeOf(typeof(NullOptions)));
+            Assert.That(_parser.GetOptions(), Is.TypeOf(typeof(NullOptions)));
         }
 
         [Test]
         public void GivenAnUnknownCommand_ThenTheCommandShouldBeHelp()
         {
-            Assert.That(_parser.GetCommand("unknown"), Is.TypeOf(typeof(NullOptions)));
+            Assert.That(_parser.GetOptions("unknown"), Is.TypeOf(typeof(NullOptions)));
         }
 
         [Test]
         public void GivenTheBcrCommand_ThenTheCommandShouldBeBcr()
         {
-            Assert.That(_parser.GetCommand("bcr"), Is.TypeOf(typeof(BcrOptions)));
+            Assert.That(_parser.GetOptions("bcr"), Is.TypeOf(typeof(BcrOptions)));
         }
 
         [Test]
         public void GivenTheBcrCommandInADifferentCase_ThenTheCommandShouldBeBcr()
         {
-            Assert.That(_parser.GetCommand("BcR"), Is.TypeOf(typeof(BcrOptions)));
+            Assert.That(_parser.GetOptions("BcR"), Is.TypeOf(typeof(BcrOptions)));
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -2,7 +2,7 @@ using System;
 using Unit4.Automation;
 using NUnit.Framework;
 using System.IO;
-using Command = Unit4.Automation.CommandParser.Command;
+using Unit4.Automation.Model;
 
 namespace Unit4.Automation.Tests
 {
@@ -20,25 +20,25 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenNoArguments_ThenTheCommandShouldBeHelp()
         {
-            Assert.That(_parser.GetCommand(), Is.EqualTo(Command.Help));
+            Assert.That(_parser.GetCommand(), Is.TypeOf(typeof(NullOptions)));
         }
 
         [Test]
         public void GivenAnUnknownCommand_ThenTheCommandShouldBeHelp()
         {
-            Assert.That(_parser.GetCommand("unknown"), Is.EqualTo(Command.Help));
+            Assert.That(_parser.GetCommand("unknown"), Is.TypeOf(typeof(NullOptions)));
         }
 
         [Test]
         public void GivenTheBcrCommand_ThenTheCommandShouldBeBcr()
         {
-            Assert.That(_parser.GetCommand("bcr"), Is.EqualTo(Command.Bcr));
+            Assert.That(_parser.GetCommand("bcr"), Is.TypeOf(typeof(BcrOptions)));
         }
 
         [Test]
         public void GivenTheBcrCommandInADifferentCase_ThenTheCommandShouldBeBcr()
         {
-            Assert.That(_parser.GetCommand("BcR"), Is.EqualTo(Command.Bcr));
+            Assert.That(_parser.GetCommand("BcR"), Is.TypeOf(typeof(BcrOptions)));
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -40,5 +40,14 @@ namespace Unit4.Automation.Tests
         {
             Assert.That(_parser.GetOptions("BcR"), Is.TypeOf(typeof(BcrOptions)));
         }
+
+        [Test]
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised()
+        {
+            var options = _parser.GetOptions("bcr", "--tier2=00T2000");
+            var bcrOptions = options as BcrOptions;
+            
+            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
+        }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -49,5 +49,32 @@ namespace Unit4.Automation.Tests
             
             Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
         }
+
+        [Test]
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeCaseInsensitiveToCamelCase()
+        {
+            var options = _parser.GetOptions("bcr", "--Tier2=00T2000");
+            var bcrOptions = options as BcrOptions;
+            
+            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
+        }
+
+        [Test]
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeCaseInsensitiveToUpperCase()
+        {
+            var options = _parser.GetOptions("bcr", "--TIER2=00T2000");
+            var bcrOptions = options as BcrOptions;
+            
+            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
+        }
+
+        [Test]
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeCaseInsensitiveToRandomCasing()
+        {
+            var options = _parser.GetOptions("bcr", "--tIEr2=00T2000");
+            var bcrOptions = options as BcrOptions;
+            
+            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
+        }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -29,49 +29,22 @@ namespace Unit4.Automation.Tests
             Assert.That(_parser.GetOptions("unknown"), Is.TypeOf(typeof(NullOptions)));
         }
 
-        [Test]
-        public void GivenTheBcrCommand_ThenTheCommandShouldBeBcr()
+        [TestCase("bcr")]
+        [TestCase("BCR")]
+        [TestCase("BcR")]
+        [TestCase("Bcr")]
+        public void GivenTheBcrCommandInAnyCase_ThenTheCommandShouldBeBcr(string command)
         {
-            Assert.That(_parser.GetOptions("bcr"), Is.TypeOf(typeof(BcrOptions)));
+            Assert.That(_parser.GetOptions(command), Is.TypeOf(typeof(BcrOptions)));
         }
 
-        [Test]
-        public void GivenTheBcrCommandInADifferentCase_ThenTheCommandShouldBeBcr()
+        [TestCase("tier2")]
+        [TestCase("Tier2")]
+        [TestCase("TIER2")]
+        [TestCase("tIEr2")]
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised(string optionName)
         {
-            Assert.That(_parser.GetOptions("BcR"), Is.TypeOf(typeof(BcrOptions)));
-        }
-
-        [Test]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised()
-        {
-            var options = _parser.GetOptions("bcr", "--tier2=00T2000");
-            var bcrOptions = options as BcrOptions;
-            
-            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
-        }
-
-        [Test]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeCaseInsensitiveToCamelCase()
-        {
-            var options = _parser.GetOptions("bcr", "--Tier2=00T2000");
-            var bcrOptions = options as BcrOptions;
-            
-            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
-        }
-
-        [Test]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeCaseInsensitiveToUpperCase()
-        {
-            var options = _parser.GetOptions("bcr", "--TIER2=00T2000");
-            var bcrOptions = options as BcrOptions;
-            
-            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
-        }
-
-        [Test]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeCaseInsensitiveToRandomCasing()
-        {
-            var options = _parser.GetOptions("bcr", "--tIEr2=00T2000");
+            var options = _parser.GetOptions("bcr", string.Format("--{0}=00T2000", optionName));
             var bcrOptions = options as BcrOptions;
             
             Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Unit4.Automation;
 using NUnit.Framework;
+using System.IO;
 using Command = Unit4.Automation.CommandParser.Command;
 
 namespace Unit4.Automation.Tests
@@ -8,36 +9,36 @@ namespace Unit4.Automation.Tests
     [TestFixture]
     public class CommandParserTests
     {
+        private CommandParser _parser;
+
+        [SetUp]
+        public void Setup()
+        {
+            _parser = new CommandParser(TextWriter.Null);
+        }
+
         [Test]
         public void GivenNoArguments_ThenTheCommandShouldBeHelp()
         {
-            var commandParser = new CommandParser();
-
-            Assert.That(commandParser.GetCommand(), Is.EqualTo(Command.Help));
+            Assert.That(_parser.GetCommand(), Is.EqualTo(Command.Help));
         }
 
         [Test]
         public void GivenAnUnknownCommand_ThenTheCommandShouldBeHelp()
         {
-            var commandParser = new CommandParser();
-
-            Assert.That(commandParser.GetCommand("unknown"), Is.EqualTo(Command.Help));
+            Assert.That(_parser.GetCommand("unknown"), Is.EqualTo(Command.Help));
         }
 
         [Test]
         public void GivenTheBcrCommand_ThenTheCommandShouldBeBcr()
         {
-            var commandParser = new CommandParser();
-
-            Assert.That(commandParser.GetCommand("bcr"), Is.EqualTo(Command.Bcr));
+            Assert.That(_parser.GetCommand("bcr"), Is.EqualTo(Command.Bcr));
         }
 
         [Test]
         public void GivenTheBcrCommandInADifferentCase_ThenTheCommandShouldBeBcr()
         {
-            var commandParser = new CommandParser();
-
-            Assert.That(commandParser.GetCommand("BcR"), Is.EqualTo(Command.Bcr));
+            Assert.That(_parser.GetCommand("BcR"), Is.EqualTo(Command.Bcr));
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -9,12 +9,12 @@ namespace Unit4.Automation.Tests
     [TestFixture]
     public class CommandParserTests
     {
-        private CommandParser _parser;
+        private CommandParser<BcrOptions> _parser;
 
         [SetUp]
         public void Setup()
         {
-            _parser = new CommandParser(TextWriter.Null);
+            _parser = new CommandParser<BcrOptions>(TextWriter.Null);
         }
 
         [Test]

--- a/Unit4/Tests/ExcelTests.cs
+++ b/Unit4/Tests/ExcelTests.cs
@@ -18,7 +18,7 @@ namespace Unit4.Automation.Tests
             {
                 var excel = new Excel();
 
-                Assert.That(() => excel.WriteToExcel(tempFile.Path, new Bcr() { Lines = new List<BcrLine>() }), Throws.Nothing);
+                Assert.That(() => excel.Write(tempFile.Path, new Bcr() { Lines = new List<BcrLine>() }), Throws.Nothing);
             }
         }
 

--- a/Unit4/Tests/ExcelTests.cs
+++ b/Unit4/Tests/ExcelTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Unit4.Automation.Model;
+using System.Linq;
 
 namespace Unit4.Automation.Tests
 {
@@ -18,7 +19,7 @@ namespace Unit4.Automation.Tests
             {
                 var excel = new Excel();
 
-                Assert.That(() => excel.Write(tempFile.Path, new Bcr() { Lines = new List<BcrLine>() }), Throws.Nothing);
+                Assert.That(() => excel.Write(tempFile.Path, new Bcr(Enumerable.Empty<BcrLine>())), Throws.Nothing);
             }
         }
 

--- a/Unit4/Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4/Tests/ReportRunnerFactoryTests.cs
@@ -17,13 +17,29 @@ namespace Unit4.Automation.Tests
 
             Assert.That(factory.Create(options), Is.TypeOf(typeof(ReportRunner)));
         }
+
+        [Test]
+        public void GivenNullOptions_ThenWeShouldGetNullRunner()
+        {
+            var factory = new ReportRunnerFactory();
+
+            var options = new NullOptions();
+
+            Assert.That(factory.Create(options), Is.TypeOf(typeof(NullRunner)));
+        }
     }
 
     internal class ReportRunnerFactory
     {
-        public ReportRunner Create(IOptions options)
+        public IRunner Create(IOptions options)
         {
             return new ReportRunner();
         }
+    }
+
+    internal class NullRunner : IRunner
+    {
+        public void Run()
+        {}
     }
 }

--- a/Unit4/Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4/Tests/ReportRunnerFactoryTests.cs
@@ -28,18 +28,4 @@ namespace Unit4.Automation.Tests
             Assert.That(factory.Create(options), Is.TypeOf(typeof(NullRunner)));
         }
     }
-
-    internal class ReportRunnerFactory
-    {
-        public IRunner Create(IOptions options)
-        {
-            var bcrOptions = options as BcrOptions;
-            if (bcrOptions != null)
-            {
-                return new ReportRunner();
-            }
-
-            return new NullRunner();
-        }
-    }
 }

--- a/Unit4/Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4/Tests/ReportRunnerFactoryTests.cs
@@ -15,7 +15,7 @@ namespace Unit4.Automation.Tests
 
             var options = new BcrOptions();
 
-            Assert.That(factory.Create(options), Is.TypeOf(typeof(ReportRunner)));
+            Assert.That(factory.Create(options), Is.TypeOf(typeof(BcrReportRunner)));
         }
 
         [Test]

--- a/Unit4/Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4/Tests/ReportRunnerFactoryTests.cs
@@ -23,7 +23,7 @@ namespace Unit4.Automation.Tests
     {
         public ReportRunner Create(IOptions options)
         {
-            throw new NotImplementedException();
+            return new ReportRunner();
         }
     }
 }

--- a/Unit4/Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4/Tests/ReportRunnerFactoryTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
+using NUnit.Framework;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    internal class ReportRunnerFactoryTests
+    {
+        [Test]
+        public void GivenBcrOptions_ThenWeShouldGetBcrRunner()
+        {
+            var factory = new ReportRunnerFactory();
+
+            var options = new BcrOptions();
+
+            Assert.That(factory.Create(options), Is.TypeOf(typeof(ReportRunner)));
+        }
+    }
+
+    internal class ReportRunnerFactory
+    {
+        public ReportRunner Create(IOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Unit4/Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4/Tests/ReportRunnerFactoryTests.cs
@@ -33,13 +33,13 @@ namespace Unit4.Automation.Tests
     {
         public IRunner Create(IOptions options)
         {
-            return new ReportRunner();
-        }
-    }
+            var bcrOptions = options as BcrOptions;
+            if (bcrOptions != null)
+            {
+                return new ReportRunner();
+            }
 
-    internal class NullRunner : IRunner
-    {
-        public void Run()
-        {}
+            return new NullRunner();
+        }
     }
 }

--- a/Unit4/Tests/SerializableRoundTripTests.cs
+++ b/Unit4/Tests/SerializableRoundTripTests.cs
@@ -2,6 +2,7 @@ using System;
 using NUnit.Framework;
 using Unit4.Automation.Model;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Unit4.Automation.Tests
 {
@@ -21,7 +22,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void CanSerializeThenDeserializeTypeBcr()
         {
-            var obj = new Bcr() { Lines = new BcrLine[0] };
+            var obj = new Bcr(Enumerable.Empty<BcrLine>());
 
             var json = JsonConvert.SerializeObject(obj);
 

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -120,6 +120,8 @@
     <Compile Include="Interfaces\IFile.cs" />
     <Compile Include="Interfaces\IOptions.cs" />
     <Compile Include="Interfaces\IRunner.cs" />
+    <Compile Include="Interfaces\IBcrReader.cs" />
+    <Compile Include="Interfaces\IBcrWriter.cs" />
     <Compile Include="Tests\Unit4WebProviderTests.cs" />
     <Compile Include="Tests\ExcelTests.cs" />
     <Compile Include="Tests\CostCentreHierarchyTests.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -101,7 +101,7 @@
     <Compile Include="ReportEngine\Unit4WebProvider.cs" />
     <Compile Include="ReportEngine\Unit4WebConnector.cs" />
     <Compile Include="NullRunner.cs" />
-    <Compile Include="ReportRunner.cs" />
+    <Compile Include="BcrReportRunner.cs" />
     <Compile Include="ReportRunnerFactory.cs" />
     <Compile Include="BcrReport.cs" />
     <Compile Include="Cache.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -102,6 +102,7 @@
     <Compile Include="ReportEngine\Unit4WebConnector.cs" />
     <Compile Include="NullRunner.cs" />
     <Compile Include="BcrReportRunner.cs" />
+    <Compile Include="BcrReader.cs" />
     <Compile Include="ReportRunnerFactory.cs" />
     <Compile Include="BcrReport.cs" />
     <Compile Include="Cache.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -93,6 +93,8 @@
     <Compile Include="Model\CostCentre.cs" />
     <Compile Include="Model\Bcr.cs" />
     <Compile Include="Model\SerializableCostCentreList.cs" />
+    <Compile Include="Model\NullOptions.cs" />
+    <Compile Include="Model\BcrOptions.cs" />
     <Compile Include="Credentials.cs" />
     <Compile Include="ReportEngine\Unit4Engine.cs" />
     <Compile Include="ReportEngine\Unit4EngineFactory.cs" />
@@ -113,6 +115,7 @@
     <Compile Include="Interfaces\ILogging.cs" />
     <Compile Include="Interfaces\ICache.cs" />
     <Compile Include="Interfaces\IFile.cs" />
+    <Compile Include="Interfaces\IOptions.cs" />
     <Compile Include="Tests\Unit4WebProviderTests.cs" />
     <Compile Include="Tests\ExcelTests.cs" />
     <Compile Include="Tests\CostCentreHierarchyTests.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -102,6 +102,7 @@
     <Compile Include="ReportEngine\Unit4WebConnector.cs" />
     <Compile Include="NullRunner.cs" />
     <Compile Include="ReportRunner.cs" />
+    <Compile Include="ReportRunnerFactory.cs" />
     <Compile Include="BcrReport.cs" />
     <Compile Include="Cache.cs" />
     <Compile Include="Report.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Interfaces\IRunner.cs" />
     <Compile Include="Interfaces\IBcrReader.cs" />
     <Compile Include="Interfaces\IBcrWriter.cs" />
+    <Compile Include="Interfaces\IBcrMiddleware.cs" />
     <Compile Include="Tests\Unit4WebProviderTests.cs" />
     <Compile Include="Tests\ExcelTests.cs" />
     <Compile Include="Tests\CostCentreHierarchyTests.cs" />
@@ -131,6 +132,7 @@
     <Compile Include="Tests\SerializableRoundTripTests.cs" />
     <Compile Include="Tests\CacheTests.cs" />
     <Compile Include="Tests\ReportRunnerFactoryTests.cs" />
+    <Compile Include="Tests\BcrReportRunnerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -100,6 +100,7 @@
     <Compile Include="ReportEngine\Unit4EngineFactory.cs" />
     <Compile Include="ReportEngine\Unit4WebProvider.cs" />
     <Compile Include="ReportEngine\Unit4WebConnector.cs" />
+    <Compile Include="NullRunner.cs" />
     <Compile Include="ReportRunner.cs" />
     <Compile Include="BcrReport.cs" />
     <Compile Include="Cache.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Tests\CacheTests.cs" />
     <Compile Include="Tests\ReportRunnerFactoryTests.cs" />
     <Compile Include="Tests\BcrReportRunnerTests.cs" />
+    <Compile Include="Tests\BcrFilterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -79,6 +79,9 @@
     <Reference Include="Microsoft.Office.Interop.Excel">
       <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
     </Reference>
+    <Reference Include="CommandLine">
+      <HintPath>..\packages\CommandLineParser.2.2.1\lib\net40\CommandLine.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -103,6 +103,7 @@
     <Compile Include="NullRunner.cs" />
     <Compile Include="BcrReportRunner.cs" />
     <Compile Include="BcrReader.cs" />
+    <Compile Include="BcrFilter.cs" />
     <Compile Include="ReportRunnerFactory.cs" />
     <Compile Include="BcrReport.cs" />
     <Compile Include="Cache.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Tests\CommandParserTests.cs" />
     <Compile Include="Tests\SerializableRoundTripTests.cs" />
     <Compile Include="Tests\CacheTests.cs" />
+    <Compile Include="Tests\ReportRunnerFactoryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Interfaces\ICache.cs" />
     <Compile Include="Interfaces\IFile.cs" />
     <Compile Include="Interfaces\IOptions.cs" />
+    <Compile Include="Interfaces\IRunner.cs" />
     <Compile Include="Tests\Unit4WebProviderTests.cs" />
     <Compile Include="Tests\ExcelTests.cs" />
     <Compile Include="Tests\CostCentreHierarchyTests.cs" />

--- a/Unit4/packages.config
+++ b/Unit4/packages.config
@@ -8,4 +8,5 @@
     <package id="System.ValueTuple" version="4.4.0" />
     <package id="Castle.Core" version="4.2.1" />
     <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" />
+    <package id="CommandLineParser" version="2.2.1" />
 </packages>

--- a/build-tools.psm1
+++ b/build-tools.psm1
@@ -13,8 +13,8 @@ function Test {
     & ".\packages\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe" .\Unit4\bin\Debug\unit4-automation.exe
 }
 
-function Run {
-    & ".\Unit4\bin\Debug\unit4-automation.exe" bcr
+function Run([String] $options = "") {
+    & ".\Unit4\bin\Debug\unit4-automation.exe" bcr $options
 }
 
 function Help {


### PR DESCRIPTION
This uses the [command line parser library](https://github.com/commandlineparser/commandline/wiki)

It moves the code over to this and adds a tier 2 option as an example.

Todo:
- [x] change `BcrFilter` to use an if rather than a ternary (problem with array and `.Count`)
- [x] move `BcrFilter` to its own file
- [x] use `BcrFilter` in `ReportRunnerFactory`
- [x] test case sensitivity in tier 2
- [x] stop tests writing to the console