### PR TITLE
Allow comma separated tier2 arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 This provides automation for [Unit4's Business World On!](https://www.unit4.com/uki/applications/erp/business-world) (formerly known as Agresso).
 
 It makes SOAP requests using Unit4's _Resql_ langauge. It pulls together many of these requests to form an overall BCR, which it then writes to Excel.
+
+It uses the [commandlineparser](https://github.com/commandlineparser/commandline/wiki) library.

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -21,7 +21,7 @@ namespace Unit4.Automation
                 return bcr;
             }
 
-            return new Bcr(bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2)).ToList());
+            return new Bcr(bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2.First())).ToList());
         }
     }
 }

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -21,8 +21,7 @@ namespace Unit4.Automation
                 return bcr;
             }
 
-            var matchingLines = bcr.Lines.Where(x => _options.Tier2.Any(y => string.Equals(x.CostCentre.Tier2, y))).ToList();
-            return new Bcr(matchingLines);
+            return new Bcr(bcr.Lines.Where(x => x.CostCentre.Matches(_options)).ToList());
         }
     }
 }

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -21,7 +21,8 @@ namespace Unit4.Automation
                 return bcr;
             }
 
-            return new Bcr(bcr.Lines.Where(x => x.CostCentre.Tier2.Equals(_options.Tier2.First())).ToList());
+            var matchingLines = bcr.Lines.Where(x => _options.Tier2.Any(y => string.Equals(x.CostCentre.Tier2, y))).ToList();
+            return new Bcr(matchingLines);
         }
     }
 }

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -16,7 +16,7 @@ namespace Unit4.Automation
 
         public Bcr Use(Bcr bcr)
         {
-            if (_options.Tier2 == null)
+            if (_options.Tier2 == null || !_options.Tier2.Any())
             {
                 return bcr;
             }

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -16,12 +16,22 @@ namespace Unit4.Automation
 
         public Bcr Use(Bcr bcr)
         {
-            if (_options.Tier2 == null || !_options.Tier2.Any())
+            if (_options.Tier2 == null)
             {
                 return bcr;
             }
 
-            return new Bcr(bcr.Lines.Where(x => x.CostCentre.Matches(_options)).ToList());
+            return new Bcr(bcr.Lines.Where(x => Matches(x.CostCentre)).ToList());
+        }
+
+        private bool Matches(CostCentre costCentre)
+        {
+            return MatchesTier2(costCentre);
+        }
+
+        private bool MatchesTier2(CostCentre costCentre)
+        {
+            return _options.Tier2 == null || !_options.Tier2.Any() || _options.Tier2.Any(x => string.Equals(x, costCentre.Tier2));
         }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -9,17 +9,17 @@ namespace Unit4.Automation.Model
     [Verb("bcr", HelpText = "Produce a BCR.")]
     internal class BcrOptions : IOptions
     {
-        private readonly string _tier2;
+        private readonly IEnumerable<string> _tier2;
 
         public BcrOptions() : this(null)
         {}
 
-        public BcrOptions(string tier2)
+        public BcrOptions(IEnumerable<string> tier2)
         {
             _tier2 = tier2;
         }
 
         [Option(HelpText = "Filter by a tier 2 code.")]
-        public string Tier2 { get { return _tier2; } }
+        public IEnumerable<string> Tier2 { get { return _tier2; } }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -19,7 +19,7 @@ namespace Unit4.Automation.Model
             _tier2 = tier2;
         }
 
-        [Option(HelpText = "Filter by a tier 2 code.")]
+        [Option(HelpText = "Filter by a tier 2 code.", Separator=',')]
         public IEnumerable<string> Tier2 { get { return _tier2; } }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -11,7 +11,7 @@ namespace Unit4.Automation.Model
     {
         private readonly IEnumerable<string> _tier2;
 
-        public BcrOptions() : this(null)
+        public BcrOptions() : this(Enumerable.Empty<string>())
         {}
 
         public BcrOptions(IEnumerable<string> tier2)
@@ -20,6 +20,17 @@ namespace Unit4.Automation.Model
         }
 
         [Option(HelpText = "Filter by a tier 2 code.", Separator=',')]
-        public IEnumerable<string> Tier2 { get { return _tier2; } }
+        public IEnumerable<string> Tier2
+        {
+            get
+            {
+                if (_tier2 == null)
+                {
+                    return Enumerable.Empty<string>();
+                }
+
+                return _tier2.Where(x => !string.Equals(x, string.Empty));
+            }
+        }
     }
 }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Linq;
 
-namespace Unit4
+namespace Unit4.Automation.Model
 {
     internal class CostCentre
     {
@@ -15,5 +16,10 @@ namespace Unit4
         public string Tier3Name { get; set; }
         public string Tier4Name { get; set; }
         public string CostCentreName { get; set; }
+
+        public bool Matches(BcrOptions options)
+        {
+            return options.Tier2.Any(x => string.Equals(x, Tier2));
+        }
     }
 }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -16,10 +16,5 @@ namespace Unit4.Automation.Model
         public string Tier3Name { get; set; }
         public string Tier4Name { get; set; }
         public string CostCentreName { get; set; }
-
-        public bool Matches(BcrOptions options)
-        {
-            return options.Tier2.Any(x => string.Equals(x, Tier2));
-        }
     }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -63,5 +63,32 @@ namespace Unit4.Automation.Tests
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
+
+        [Test]
+        public void GivenTier2OptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded()
+        {
+            var options = new BcrOptions(new string[] { "firstTier2", "secondTier2" });
+
+            var filter = new BcrFilter(options);
+
+            var firstBcrLine = new BcrLine() {
+                        CostCentre = new CostCentre() {
+                            Tier2 = "firstTier2"
+                        }
+                    };
+            var secondBcrLine = new BcrLine() {
+                        CostCentre = new CostCentre() {
+                            Tier2 = "secondTier2"
+                        }
+                    };
+            var thirdBcrLine = new BcrLine() {
+                        CostCentre = new CostCentre() {
+                            Tier2 = "thirdTier2"
+                        }
+                    };
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine, thirdBcrLine });
+
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
+        }
     }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -13,7 +13,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2Option_ThenLinesNotMatchingThatTier2ShouldNotBeIncluded()
         {
-            var options = new BcrOptions("tier2");
+            var options = new BcrOptions(new string[] { "tier2" });
 
             var filter = new BcrFilter(options);
 
@@ -31,7 +31,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2Option_ThenLinesMatchingThatTier2ShouldBeIncluded()
         {
-            var options = new BcrOptions("tier2");
+            var options = new BcrOptions(new string[] { "tier2" });
 
             var filter = new BcrFilter(options);
 

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -17,13 +17,7 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr(new BcrLine[] {
-                    new BcrLine() {
-                        CostCentre = new CostCentre() {
-                            Tier2 = "notTheRightTier2"
-                        }
-                    },
-                });
+            var bcr = new Bcr(new BcrLine[] { LineWithTier2("notTheRightTier2") });
 
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
@@ -35,13 +29,7 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr(new BcrLine[] {
-                    new BcrLine() {
-                        CostCentre = new CostCentre() {
-                            Tier2 = "tier2"
-                        }
-                    },
-                });
+            var bcr = new Bcr(new BcrLine[] { LineWithTier2("tier2") });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
@@ -53,13 +41,7 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr(new BcrLine[] {
-                    new BcrLine() {
-                        CostCentre = new CostCentre() {
-                            Tier2 = "tier2"
-                        }
-                    },
-                });
+            var bcr = new Bcr(new BcrLine[] { LineWithTier2("tier2") });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
@@ -71,24 +53,22 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var firstBcrLine = new BcrLine() {
-                        CostCentre = new CostCentre() {
-                            Tier2 = "firstTier2"
-                        }
-                    };
-            var secondBcrLine = new BcrLine() {
-                        CostCentre = new CostCentre() {
-                            Tier2 = "secondTier2"
-                        }
-                    };
-            var thirdBcrLine = new BcrLine() {
-                        CostCentre = new CostCentre() {
-                            Tier2 = "thirdTier2"
-                        }
-                    };
+            var firstBcrLine = LineWithTier2("firstTier2");
+            var secondBcrLine = LineWithTier2("secondTier2");
+            var thirdBcrLine = LineWithTier2("thirdTier2");
+
             var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine, thirdBcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
+        }
+
+        private BcrLine LineWithTier2(string tier2)
+        {
+            return new BcrLine() {
+                CostCentre = new CostCentre() {
+                    Tier2 = tier2
+                }
+            };
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -3,6 +3,7 @@ using Unit4.Automation;
 using NUnit.Framework;
 using System.IO;
 using Unit4.Automation.Model;
+using System.Linq;
 
 namespace Unit4.Automation.Tests
 {
@@ -47,7 +48,18 @@ namespace Unit4.Automation.Tests
             var options = _parser.GetOptions("bcr", string.Format("--{0}=00T2000", optionName));
             var bcrOptions = options as BcrOptions;
             
-            Assert.That(bcrOptions.Tier2, Is.EqualTo("00T2000"));
+            Assert.That(bcrOptions.Tier2.Single(), Is.EqualTo("00T2000"));
+        }
+
+        [Test]
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldTakeCommaSeparatedValues()
+        {
+            var commandSeparatedTier2s = new string[] { "firstTier2", "secondTier2" };
+            
+            var options = _parser.GetOptions("bcr", string.Format("--tier2={0}", string.Join(",", commandSeparatedTier2s)));
+            var bcrOptions = options as BcrOptions;
+
+            Assert.That(bcrOptions.Tier2, Is.EquivalentTo(commandSeparatedTier2s));
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -61,5 +61,17 @@ namespace Unit4.Automation.Tests
 
             Assert.That(bcrOptions.Tier2, Is.EquivalentTo(commandSeparatedTier2s));
         }
+
+        [TestCase("myTier2,,,")]
+        [TestCase(",myTier2,,")]
+        [TestCase(",,myTier2,")]
+        [TestCase(",,,myTier2")]
+        public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(string option)
+        {
+            var options = _parser.GetOptions("bcr", string.Format("--tier2={0}", option));
+            var bcrOptions = options as BcrOptions;
+
+            Assert.That(bcrOptions.Tier2, Is.EquivalentTo(new string[] { "myTier2" }));
+        }
     }
 }

--- a/build-tools.psm1
+++ b/build-tools.psm1
@@ -13,7 +13,7 @@ function Test {
     & ".\packages\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe" .\Unit4\bin\Debug\unit4-automation.exe
 }
 
-function Run([String] $options = "") {
+function Run([String[]] $options = "") {
     & ".\Unit4\bin\Debug\unit4-automation.exe" bcr $options
 }
 


### PR DESCRIPTION
This makes it possible to do:
```
unit4-automation.exe bcr --tier2=foo
unit4-automation.exe bcr --tier2=foo,bar
unit4-automation.exe bcr --tier2=foo,bar,fee
```
etc