### PR TITLE
Add a tier3 option to the bcr command

### DIFF
--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -26,17 +26,22 @@ namespace Unit4.Automation
 
         private bool Matches(CostCentre costCentre)
         {
-            return MatchesTier2(costCentre) && MatchesTier3(costCentre);
+            var matchesTier2 = HasTier2 && MatchesTier2(costCentre);
+            var matchesTier3 = HasTier3 && MatchesTier3(costCentre);
+            return matchesTier2 || matchesTier3 || !HasTier2 && !HasTier3;
         }
+
+        private bool HasTier2 { get { return _options.Tier2 != null && _options.Tier2.Any(); } }
+        private bool HasTier3 { get { return _options.Tier3 != null && _options.Tier3.Any(); } }
 
         private bool MatchesTier2(CostCentre costCentre)
         {
-            return _options.Tier2 == null || !_options.Tier2.Any() || _options.Tier2.Any(x => string.Equals(x, costCentre.Tier2));
+            return  _options.Tier2.Any(x => string.Equals(x, costCentre.Tier2));
         }
 
         private bool MatchesTier3(CostCentre costCentre)
         {
-            return _options.Tier3 == null || !_options.Tier3.Any() || _options.Tier3.Any(x => string.Equals(x, costCentre.Tier3));
+            return _options.Tier3.Any(x => string.Equals(x, costCentre.Tier3));
         }
     }
 }

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -26,9 +26,14 @@ namespace Unit4.Automation
 
         private bool Matches(CostCentre costCentre)
         {
+            if (!HasTier2 && !HasTier3)
+            {
+                return true;
+            }
+
             var matchesTier2 = HasTier2 && MatchesTier2(costCentre);
             var matchesTier3 = HasTier3 && MatchesTier3(costCentre);
-            return matchesTier2 || matchesTier3 || !HasTier2 && !HasTier3;
+            return matchesTier2 || matchesTier3;
         }
 
         private bool HasTier2 { get { return _options.Tier2 != null && _options.Tier2.Any(); } }

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -26,12 +26,17 @@ namespace Unit4.Automation
 
         private bool Matches(CostCentre costCentre)
         {
-            return MatchesTier2(costCentre);
+            return MatchesTier2(costCentre) && MatchesTier3(costCentre);
         }
 
         private bool MatchesTier2(CostCentre costCentre)
         {
             return _options.Tier2 == null || !_options.Tier2.Any() || _options.Tier2.Any(x => string.Equals(x, costCentre.Tier2));
+        }
+
+        private bool MatchesTier3(CostCentre costCentre)
+        {
+            return _options.Tier3 == null || !_options.Tier3.Any() || _options.Tier3.Any(x => string.Equals(x, costCentre.Tier3));
         }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -35,7 +35,7 @@ namespace Unit4.Automation.Model
             }
         }
 
-        [Option]
+        [Option(Separator=',')]
         public IEnumerable<string> Tier3
         {
             get

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -11,10 +11,10 @@ namespace Unit4.Automation.Model
     {
         private readonly IEnumerable<string> _tier2;
 
-        public BcrOptions() : this(Enumerable.Empty<string>())
+        public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {}
 
-        public BcrOptions(IEnumerable<string> tier2)
+        public BcrOptions(IEnumerable<string> tier2, IEnumerable<string> tier3)
         {
             _tier2 = tier2;
         }
@@ -30,6 +30,15 @@ namespace Unit4.Automation.Model
                 }
 
                 return _tier2.Where(x => !string.Equals(x, string.Empty));
+            }
+        }
+
+        [Option]
+        public IEnumerable<string> tier3
+        {
+            get
+            {
+                throw new NotSupportedException();
             }
         }
     }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -35,7 +35,7 @@ namespace Unit4.Automation.Model
             }
         }
 
-        [Option(Separator=',')]
+        [Option(HelpText = "Filter by a tier 3 code.", Separator=',')]
         public IEnumerable<string> Tier3
         {
             get

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -10,6 +10,7 @@ namespace Unit4.Automation.Model
     internal class BcrOptions : IOptions
     {
         private readonly IEnumerable<string> _tier2;
+        private readonly IEnumerable<string> _tier3;
 
         public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {}
@@ -17,6 +18,7 @@ namespace Unit4.Automation.Model
         public BcrOptions(IEnumerable<string> tier2, IEnumerable<string> tier3)
         {
             _tier2 = tier2;
+            _tier3 = tier3;
         }
 
         [Option(HelpText = "Filter by a tier 2 code.", Separator=',')]
@@ -38,7 +40,12 @@ namespace Unit4.Automation.Model
         {
             get
             {
-                throw new NotSupportedException();
+                if (_tier3 == null)
+                {
+                    return Enumerable.Empty<string>();
+                }
+
+                return _tier3.Where(x => !string.Equals(x, string.Empty));
             }
         }
     }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -34,7 +34,7 @@ namespace Unit4.Automation.Model
         }
 
         [Option]
-        public IEnumerable<string> tier3
+        public IEnumerable<string> Tier3
         {
             get
             {

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -60,16 +60,19 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
         }
 
-        [Test]
-        public void GivenMatchOnTier2Only_ThenTheLineShouldBeIncluded()
+        [TestCase(Criteria.Tier2)]
+        public void GivenMatchOnTier2Only_ThenTheLineShouldBeIncluded(params Criteria[] criteria)
         {
             var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
 
-            var firstBcrLine = A.BcrLine().WithTier2("1").WithTier3("0").Build();
+            var tiers = (Criteria[])Enum.GetValues(typeof(Criteria));
+            var blankLine = tiers.Aggregate(A.BcrLine(), (builder, t) => builder.With(t, "0"));
+            
+            var bcrLine = criteria.Aggregate(blankLine, (builder, t) => builder.With(criteria, "1")).Build();
 
-            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
+            var bcr = new Bcr(new BcrLine[] { bcrLine });
 
-            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { bcrLine }));
         }
 
         [Test]

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -42,14 +42,14 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
 
-        [Test]
-        public void GivenTier2OptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded()
+        [TestCase(Criteria.Tier2)]
+        public void GivenTierOptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded(Criteria criteria)
         {
-            var filter = A.BcrFilter().WithTier2("firstTier2", "secondTier2").Build();
+            var filter = A.BcrFilter().With(criteria, "firstTier2", "secondTier2").Build();
 
-            var firstBcrLine = A.BcrLine().WithTier2("firstTier2").Build();
-            var secondBcrLine = A.BcrLine().WithTier2("secondTier2").Build();
-            var thirdBcrLine = A.BcrLine().WithTier2("thirdTier2").Build();
+            var firstBcrLine = A.BcrLine().With(criteria, "firstTier2").Build();
+            var secondBcrLine = A.BcrLine().With(criteria, "secondTier2").Build();
+            var thirdBcrLine = A.BcrLine().With(criteria, "thirdTier2").Build();
 
             var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine, thirdBcrLine });
 

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -12,9 +12,8 @@ namespace Unit4.Automation.Tests
     [TestFixture]
     internal class BcrFilterTests
     {
-        [TestCase(Criteria.Tier2)]
-        [TestCase(Criteria.Tier3)]
-        public void GivenTierOption_ThenLinesNotMatchingThatTierShouldNotBeIncluded(Criteria criteria)
+        [Test]
+        public void GivenTierOption_ThenLinesNotMatchingThatTierShouldNotBeIncluded([Values] Criteria criteria)
         {
             var filter = A.BcrFilter().With(criteria, "tier").Build();
 
@@ -23,9 +22,8 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
 
-        [TestCase(Criteria.Tier2)]
-        [TestCase(Criteria.Tier3)]
-        public void GivenTierOption_ThenLinesMatchingThatTierShouldBeIncluded(Criteria criteria)
+        [Test]
+        public void GivenTierOption_ThenLinesMatchingThatTierShouldBeIncluded([Values] Criteria criteria)
         {
             var filter = A.BcrFilter().With(criteria, "tier").Build();
 
@@ -34,9 +32,8 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
 
-        [TestCase(Criteria.Tier2)]
-        [TestCase(Criteria.Tier3)]
-        public void GivenNoTierOption_ThenAllLinesShouldBeIncluded(Criteria criteria)
+        [Test]
+        public void GivenNoTierOption_ThenAllLinesShouldBeIncluded([Values] Criteria criteria)
         {
             var filter = A.BcrFilter().Build();
 
@@ -45,9 +42,8 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
 
-        [TestCase(Criteria.Tier2)]
-        [TestCase(Criteria.Tier3)]
-        public void GivenTierOptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded(Criteria criteria)
+        [Test]
+        public void GivenTierOptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded([Values] Criteria criteria)
         {
             var filter = A.BcrFilter().With(criteria, "firstTier2", "secondTier2").Build();
 

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -76,9 +76,13 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenMatchOnNoTier_ThenTheLineShouldNotBeIncluded()
         {
-            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
-
-            var firstBcrLine = A.BcrLine().WithTier2("0").WithTier3("0").Build();
+            var allCriteria = (Criteria[])Enum.GetValues(typeof(Criteria));
+            
+            var filter = 
+                allCriteria.Aggregate(A.BcrFilter(), (builder, c) => builder.With(c, "1")).Build();
+            
+            var firstBcrLine = 
+                allCriteria.Aggregate(A.BcrLine(), (builder, c) => builder.With(c, "0")).Build();
 
             var bcr = new Bcr(new BcrLine[] { firstBcrLine });
 

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -13,9 +13,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2Option_ThenLinesNotMatchingThatTier2ShouldNotBeIncluded()
         {
-            var options = A.BcrOptions().WithTier2("tier2");
-
-            var filter = new BcrFilter(options);
+            var filter = A.BcrFilter().WithTier2("tier2").Build();
 
             var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("notTheRightTier2") });
 
@@ -25,9 +23,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2Option_ThenLinesMatchingThatTier2ShouldBeIncluded()
         {
-            var options = A.BcrOptions().WithTier2("tier2");
-
-            var filter = new BcrFilter(options);
+            var filter = A.BcrFilter().WithTier2("tier2").Build();
 
             var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("tier2") });
 
@@ -37,9 +33,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenNoTier2Option_ThenAllLinesShouldBeIncluded()
         {
-            var options = A.BcrOptions();
-
-            var filter = new BcrFilter(options);
+            var filter = A.BcrFilter().Build();
 
             var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("tier2") });
 
@@ -49,9 +43,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2OptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded()
         {
-            var options = A.BcrOptions().WithTier2("firstTier2", "secondTier2");
-
-            var filter = new BcrFilter(options);
+            var filter = A.BcrFilter().WithTier2("firstTier2", "secondTier2").Build();
 
             var firstBcrLine = A.BcrLine().WithTier2("firstTier2").Build();
             var secondBcrLine = A.BcrLine().WithTier2("secondTier2").Build();
@@ -69,9 +61,9 @@ namespace Unit4.Automation.Tests
                 return new BcrLineBuilder();
             }
 
-            public static BcrOptionsBuilder BcrOptions()
+            public static BcrFilterBuilder BcrFilter()
             {
-                return new BcrOptionsBuilder();
+                return new BcrFilterBuilder();
             }
         }
 
@@ -100,24 +92,24 @@ namespace Unit4.Automation.Tests
             }
         }
 
-        private class BcrOptionsBuilder
+        private class BcrFilterBuilder
         {
             private string[] _tier2;
 
-            public BcrOptionsBuilder WithTier2(params string[] tier2)
+            public BcrFilterBuilder WithTier2(params string[] tier2)
             {
                 _tier2 = tier2;
                 return this;
             }
 
-            public BcrOptions Build()
+            public BcrFilter Build()
             {
-                return (BcrOptions)this;
+                return (BcrFilter)this;
             }
 
-            public static implicit operator BcrOptions(BcrOptionsBuilder builder)
+            public static implicit operator BcrFilter(BcrFilterBuilder builder)
             {
-                return new BcrOptions(builder._tier2);
+                return new BcrFilter(new BcrOptions(builder._tier2));
             }
         }
     }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -17,7 +17,7 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr(new BcrLine[] { LineWithTier2("notTheRightTier2") });
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("notTheRightTier2") });
 
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
@@ -29,7 +29,7 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr(new BcrLine[] { LineWithTier2("tier2") });
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("tier2") });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
@@ -41,7 +41,7 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var bcr = new Bcr(new BcrLine[] { LineWithTier2("tier2") });
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("tier2") });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
@@ -53,22 +53,46 @@ namespace Unit4.Automation.Tests
 
             var filter = new BcrFilter(options);
 
-            var firstBcrLine = LineWithTier2("firstTier2");
-            var secondBcrLine = LineWithTier2("secondTier2");
-            var thirdBcrLine = LineWithTier2("thirdTier2");
+            var firstBcrLine = A.BcrLine().WithTier2("firstTier2").Build();
+            var secondBcrLine = A.BcrLine().WithTier2("secondTier2").Build();
+            var thirdBcrLine = A.BcrLine().WithTier2("thirdTier2").Build();
 
             var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine, thirdBcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
         }
 
-        private BcrLine LineWithTier2(string tier2)
+        private static class A
         {
-            return new BcrLine() {
-                CostCentre = new CostCentre() {
-                    Tier2 = tier2
-                }
-            };
+            public static BcrLineBuilder BcrLine()
+            {
+                return new BcrLineBuilder();
+            }
+        }
+
+        private class BcrLineBuilder
+        {
+            private string _tier2;
+            
+            public BcrLineBuilder WithTier2(string tier2)
+            {
+                _tier2 = tier2;
+                return this;
+            }
+
+            public BcrLine Build()
+            {
+                return (BcrLine)this;
+            }
+
+            public static implicit operator BcrLine(BcrLineBuilder builder)
+            {
+                return new BcrLine() {
+                    CostCentre = new CostCentre() {
+                        Tier2 = builder._tier2
+                    }
+                };
+            }
         }
     }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -13,7 +13,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2Option_ThenLinesNotMatchingThatTier2ShouldNotBeIncluded()
         {
-            var options = new BcrOptions(new string[] { "tier2" });
+            var options = A.BcrOptions().WithTier2("tier2");
 
             var filter = new BcrFilter(options);
 
@@ -25,7 +25,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2Option_ThenLinesMatchingThatTier2ShouldBeIncluded()
         {
-            var options = new BcrOptions(new string[] { "tier2" });
+            var options = A.BcrOptions().WithTier2("tier2");
 
             var filter = new BcrFilter(options);
 
@@ -37,7 +37,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenNoTier2Option_ThenAllLinesShouldBeIncluded()
         {
-            var options = new BcrOptions();
+            var options = A.BcrOptions();
 
             var filter = new BcrFilter(options);
 
@@ -49,7 +49,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier2OptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded()
         {
-            var options = new BcrOptions(new string[] { "firstTier2", "secondTier2" });
+            var options = A.BcrOptions().WithTier2("firstTier2", "secondTier2");
 
             var filter = new BcrFilter(options);
 
@@ -67,6 +67,11 @@ namespace Unit4.Automation.Tests
             public static BcrLineBuilder BcrLine()
             {
                 return new BcrLineBuilder();
+            }
+
+            public static BcrOptionsBuilder BcrOptions()
+            {
+                return new BcrOptionsBuilder();
             }
         }
 
@@ -92,6 +97,27 @@ namespace Unit4.Automation.Tests
                         Tier2 = builder._tier2
                     }
                 };
+            }
+        }
+
+        private class BcrOptionsBuilder
+        {
+            private string[] _tier2;
+
+            public BcrOptionsBuilder WithTier2(params string[] tier2)
+            {
+                _tier2 = tier2;
+                return this;
+            }
+
+            public BcrOptions Build()
+            {
+                return (BcrOptions)this;
+            }
+
+            public static implicit operator BcrOptions(BcrOptionsBuilder builder)
+            {
+                return new BcrOptions(builder._tier2);
             }
         }
     }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -13,6 +13,7 @@ namespace Unit4.Automation.Tests
         public enum Criteria { Tier2, Tier3 }
 
         [TestCase(Criteria.Tier2)]
+        [TestCase(Criteria.Tier3)]
         public void GivenTierOption_ThenLinesNotMatchingThatTierShouldNotBeIncluded(Criteria criteria)
         {
             var filter = A.BcrFilter().With(criteria, "tier").Build();
@@ -23,6 +24,7 @@ namespace Unit4.Automation.Tests
         }
 
         [TestCase(Criteria.Tier2)]
+        [TestCase(Criteria.Tier3)]
         public void GivenTierOption_ThenLinesMatchingThatTierShouldBeIncluded(Criteria criteria)
         {
             var filter = A.BcrFilter().With(criteria, "tier").Build();
@@ -33,6 +35,7 @@ namespace Unit4.Automation.Tests
         }
 
         [TestCase(Criteria.Tier2)]
+        [TestCase(Criteria.Tier3)]
         public void GivenNoTierOption_ThenAllLinesShouldBeIncluded(Criteria criteria)
         {
             var filter = A.BcrFilter().Build();
@@ -43,6 +46,7 @@ namespace Unit4.Automation.Tests
         }
 
         [TestCase(Criteria.Tier2)]
+        [TestCase(Criteria.Tier3)]
         public void GivenTierOptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded(Criteria criteria)
         {
             var filter = A.BcrFilter().With(criteria, "firstTier2", "secondTier2").Build();

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -10,12 +10,14 @@ namespace Unit4.Automation.Tests
     [TestFixture]
     public class BcrFilterTests
     {
-        [Test]
-        public void GivenTier2Option_ThenLinesNotMatchingThatTier2ShouldNotBeIncluded()
-        {
-            var filter = A.BcrFilter().WithTier2("tier2").Build();
+        public enum Criteria { Tier2 }
 
-            var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("notTheRightTier2") });
+        [TestCase(Criteria.Tier2)]
+        public void GivenTierOption_ThenLinesNotMatchingThatTierShouldNotBeIncluded(Criteria criteria)
+        {
+            var filter = A.BcrFilter().With(criteria, "tier").Build();
+
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().With(criteria, "notTheRightTier") });
 
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
@@ -71,6 +73,15 @@ namespace Unit4.Automation.Tests
         {
             private string _tier2;
             
+            public BcrLineBuilder With(Criteria criteria, string value)
+            {
+                switch (criteria)
+                {
+                    case Criteria.Tier2: return WithTier2(value);
+                    default: throw new NotSupportedException(criteria.ToString());
+                }
+            }
+
             public BcrLineBuilder WithTier2(string tier2)
             {
                 _tier2 = tier2;
@@ -96,6 +107,14 @@ namespace Unit4.Automation.Tests
         {
             private string[] _tier2;
 
+            public BcrFilterBuilder With(Criteria criteria, params string[] value)
+            {
+                switch (criteria)
+                {
+                    case Criteria.Tier2: return WithTier2(value);
+                    default: throw new NotSupportedException(criteria.ToString());
+                }
+            }
             public BcrFilterBuilder WithTier2(params string[] tier2)
             {
                 _tier2 = tier2;

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -61,30 +61,54 @@ namespace Unit4.Automation.Tests
         }
 
         [Test]
-        public void GivenDifferentTierOptions_ThenMatchAgainstLowerTierButNoMatchAgainstHigherTierShouldBeIncluded()
+        public void GivenMatchOnTier2Only_ThenTheLineShouldBeIncluded()
         {
-            var filter = A.BcrFilter().WithTier2("tier2").WithTier3("differentTier3").Build();
+            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
 
-            var firstBcrLine = A.BcrLine().WithTier2("tier2").WithTier3("differentTier3").Build();
-            var secondBcrLine = A.BcrLine().WithTier2("differentTier2").WithTier3("differentTier3").Build();
+            var firstBcrLine = A.BcrLine().WithTier2("1").WithTier3("0").Build();
 
-            var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine });
-
-            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
-        }
-
-        [Test]
-        public void GivenDifferentTierOptions_ThenMatchAgainstHigherTierButNoMatchAgainstLowerTierShouldBeIncluded()
-        {
-            var filter = A.BcrFilter().WithTier2("tier2").WithTier3("tier3").Build();
-
-            var firstBcrLine = A.BcrLine().WithTier2("tier2").WithTier3("differentTier3").Build();
-            var secondBcrLine = A.BcrLine().WithTier2("differentTier2").WithTier3("differentTier3").Build();
-
-            var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine });
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
         }
+
+        [Test]
+        public void GivenMatchOnTier3Only_ThenTheLineShouldBeIncluded()
+        {
+            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
+
+            var firstBcrLine = A.BcrLine().WithTier2("0").WithTier3("1").Build();
+
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
+
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
+        }
+
+        [Test]
+        public void GivenMatchOnTier2AndTier3_ThenTheLineShouldBeIncluded()
+        {
+            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
+
+            var firstBcrLine = A.BcrLine().WithTier2("1").WithTier3("1").Build();
+
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
+
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
+        }
+
+        [Test]
+        public void GivenMatchOnNoTier_ThenTheLineShouldNotBeIncluded()
+        {
+            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
+
+            var firstBcrLine = A.BcrLine().WithTier2("0").WithTier3("0").Build();
+
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
+
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.Empty);
+        }
+
+
 
         private static class A
         {

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -65,12 +65,25 @@ namespace Unit4.Automation.Tests
         {
             var filter = A.BcrFilter().WithTier2("tier2").WithTier3("differentTier3").Build();
 
-            var firstBcrLine = A.BcrLine().WithTier2("tier2").Build();
+            var firstBcrLine = A.BcrLine().WithTier2("tier2").WithTier3("differentTier3").Build();
             var secondBcrLine = A.BcrLine().WithTier2("differentTier2").WithTier3("differentTier3").Build();
 
             var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
+        }
+
+        [Test]
+        public void GivenDifferentTierOptions_ThenMatchAgainstHigherTierButNoMatchAgainstLowerTierShouldBeIncluded()
+        {
+            var filter = A.BcrFilter().WithTier2("tier2").WithTier3("tier3").Build();
+
+            var firstBcrLine = A.BcrLine().WithTier2("tier2").WithTier3("differentTier3").Build();
+            var secondBcrLine = A.BcrLine().WithTier2("differentTier2").WithTier3("differentTier3").Build();
+
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine });
+
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
         }
 
         private static class A

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -45,11 +45,11 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTierOptionWithMultipleValues_ThenLinesMatchingThatAnyOfThoseValuesShouldBeIncluded([Values] Criteria criteria)
         {
-            var filter = A.BcrFilter().With(criteria, "firstTier2", "secondTier2").Build();
+            var filter = A.BcrFilter().With(criteria, "firstTier", "secondTier").Build();
 
-            var firstBcrLine = A.BcrLine().With(criteria, "firstTier2").Build();
-            var secondBcrLine = A.BcrLine().With(criteria, "secondTier2").Build();
-            var thirdBcrLine = A.BcrLine().With(criteria, "thirdTier2").Build();
+            var firstBcrLine = A.BcrLine().With(criteria, "firstTier").Build();
+            var secondBcrLine = A.BcrLine().With(criteria, "secondTier").Build();
+            var thirdBcrLine = A.BcrLine().With(criteria, "thirdTier").Build();
 
             var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine, thirdBcrLine });
 

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -61,6 +61,8 @@ namespace Unit4.Automation.Tests
         }
 
         [TestCase(Criteria.Tier2)]
+        [TestCase(Criteria.Tier3)]
+        [TestCase(Criteria.Tier2, Criteria.Tier3)]
         public void GivenMatchOnTier2Only_ThenTheLineShouldBeIncluded(params Criteria[] criteria)
         {
             var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
@@ -68,35 +70,11 @@ namespace Unit4.Automation.Tests
             var tiers = (Criteria[])Enum.GetValues(typeof(Criteria));
             var blankLine = tiers.Aggregate(A.BcrLine(), (builder, t) => builder.With(t, "0"));
             
-            var bcrLine = criteria.Aggregate(blankLine, (builder, t) => builder.With(criteria, "1")).Build();
+            var bcrLine = criteria.Aggregate(blankLine, (builder, t) => builder.With(t, "1")).Build();
 
             var bcr = new Bcr(new BcrLine[] { bcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { bcrLine }));
-        }
-
-        [Test]
-        public void GivenMatchOnTier3Only_ThenTheLineShouldBeIncluded()
-        {
-            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
-
-            var firstBcrLine = A.BcrLine().WithTier2("0").WithTier3("1").Build();
-
-            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
-
-            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
-        }
-
-        [Test]
-        public void GivenMatchOnTier2AndTier3_ThenTheLineShouldBeIncluded()
-        {
-            var filter = A.BcrFilter().WithTier2("1").WithTier3("1").Build();
-
-            var firstBcrLine = A.BcrLine().WithTier2("1").WithTier3("1").Build();
-
-            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
-
-            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine }));
         }
 
         [Test]

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -60,6 +60,19 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
         }
 
+        [Test]
+        public void GivenDifferentTierOptions_ThenMatchAgainstLowerTierButNoMatchAgainstHigherTierShouldBeIncluded()
+        {
+            var filter = A.BcrFilter().WithTier2("tier2").WithTier3("differentTier3").Build();
+
+            var firstBcrLine = A.BcrLine().WithTier2("tier2").Build();
+            var secondBcrLine = A.BcrLine().WithTier2("differentTier2").WithTier3("differentTier3").Build();
+
+            var bcr = new Bcr(new BcrLine[] { firstBcrLine, secondBcrLine });
+
+            Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
+        }
+
         private static class A
         {
             public static BcrLineBuilder BcrLine()

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -10,7 +10,7 @@ namespace Unit4.Automation.Tests
     [TestFixture]
     public class BcrFilterTests
     {
-        public enum Criteria { Tier2 }
+        public enum Criteria { Tier2, Tier3 }
 
         [TestCase(Criteria.Tier2)]
         public void GivenTierOption_ThenLinesNotMatchingThatTierShouldNotBeIncluded(Criteria criteria)
@@ -72,12 +72,14 @@ namespace Unit4.Automation.Tests
         private class BcrLineBuilder
         {
             private string _tier2;
+            private string _tier3;
             
             public BcrLineBuilder With(Criteria criteria, string value)
             {
                 switch (criteria)
                 {
                     case Criteria.Tier2: return WithTier2(value);
+                    case Criteria.Tier3: return WithTier3(value);
                     default: throw new NotSupportedException(criteria.ToString());
                 }
             }
@@ -85,6 +87,12 @@ namespace Unit4.Automation.Tests
             public BcrLineBuilder WithTier2(string tier2)
             {
                 _tier2 = tier2;
+                return this;
+            }
+
+            public BcrLineBuilder WithTier3(string tier3)
+            {
+                _tier3 = tier3;
                 return this;
             }
 
@@ -97,7 +105,8 @@ namespace Unit4.Automation.Tests
             {
                 return new BcrLine() {
                     CostCentre = new CostCentre() {
-                        Tier2 = builder._tier2
+                        Tier2 = builder._tier2,
+                        Tier3 = builder._tier3
                     }
                 };
             }
@@ -106,18 +115,26 @@ namespace Unit4.Automation.Tests
         private class BcrFilterBuilder
         {
             private string[] _tier2;
+            private string[] _tier3;
 
             public BcrFilterBuilder With(Criteria criteria, params string[] value)
             {
                 switch (criteria)
                 {
                     case Criteria.Tier2: return WithTier2(value);
+                    case Criteria.Tier3: return WithTier3(value);
                     default: throw new NotSupportedException(criteria.ToString());
                 }
             }
             public BcrFilterBuilder WithTier2(params string[] tier2)
             {
                 _tier2 = tier2;
+                return this;
+            }
+
+            public BcrFilterBuilder WithTier3(params string[] tier3)
+            {
+                _tier3 = tier3;
                 return this;
             }
 
@@ -128,7 +145,7 @@ namespace Unit4.Automation.Tests
 
             public static implicit operator BcrFilter(BcrFilterBuilder builder)
             {
-                return new BcrFilter(new BcrOptions(builder._tier2));
+                return new BcrFilter(new BcrOptions(builder._tier2, builder._tier3));
             }
         }
     }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -22,12 +22,12 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines, Is.Empty);
         }
 
-        [Test]
-        public void GivenTier2Option_ThenLinesMatchingThatTier2ShouldBeIncluded()
+        [TestCase(Criteria.Tier2)]
+        public void GivenTierOption_ThenLinesMatchingThatTierShouldBeIncluded(Criteria criteria)
         {
-            var filter = A.BcrFilter().WithTier2("tier2").Build();
+            var filter = A.BcrFilter().With(criteria, "tier").Build();
 
-            var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("tier2") });
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().With(criteria, "tier") });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -77,14 +77,14 @@ namespace Unit4.Automation.Tests
         public void GivenMatchOnNoTier_ThenTheLineShouldNotBeIncluded()
         {
             var allCriteria = (Criteria[])Enum.GetValues(typeof(Criteria));
-            
+
             var filter = 
                 allCriteria.Aggregate(A.BcrFilter(), (builder, c) => builder.With(c, "1")).Build();
             
-            var firstBcrLine = 
+            var bcrLine = 
                 allCriteria.Aggregate(A.BcrLine(), (builder, c) => builder.With(c, "0")).Build();
 
-            var bcr = new Bcr(new BcrLine[] { firstBcrLine });
+            var bcr = new Bcr(new BcrLine[] { bcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.Empty);
         }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -4,14 +4,14 @@ using NUnit.Framework;
 using Unit4.Automation.Model;
 using Unit4.Automation.Interfaces;
 using System.Linq;
+using Unit4.Automation.Tests.Helpers;
+using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
 
 namespace Unit4.Automation.Tests
 {
     [TestFixture]
-    public class BcrFilterTests
+    internal class BcrFilterTests
     {
-        public enum Criteria { Tier2, Tier3 }
-
         [TestCase(Criteria.Tier2)]
         [TestCase(Criteria.Tier3)]
         public void GivenTierOption_ThenLinesNotMatchingThatTierShouldNotBeIncluded(Criteria criteria)
@@ -87,101 +87,6 @@ namespace Unit4.Automation.Tests
             var bcr = new Bcr(new BcrLine[] { firstBcrLine });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.Empty);
-        }
-
-
-
-        private static class A
-        {
-            public static BcrLineBuilder BcrLine()
-            {
-                return new BcrLineBuilder();
-            }
-
-            public static BcrFilterBuilder BcrFilter()
-            {
-                return new BcrFilterBuilder();
-            }
-        }
-
-        private class BcrLineBuilder
-        {
-            private string _tier2;
-            private string _tier3;
-            
-            public BcrLineBuilder With(Criteria criteria, string value)
-            {
-                switch (criteria)
-                {
-                    case Criteria.Tier2: return WithTier2(value);
-                    case Criteria.Tier3: return WithTier3(value);
-                    default: throw new NotSupportedException(criteria.ToString());
-                }
-            }
-
-            public BcrLineBuilder WithTier2(string tier2)
-            {
-                _tier2 = tier2;
-                return this;
-            }
-
-            public BcrLineBuilder WithTier3(string tier3)
-            {
-                _tier3 = tier3;
-                return this;
-            }
-
-            public BcrLine Build()
-            {
-                return (BcrLine)this;
-            }
-
-            public static implicit operator BcrLine(BcrLineBuilder builder)
-            {
-                return new BcrLine() {
-                    CostCentre = new CostCentre() {
-                        Tier2 = builder._tier2,
-                        Tier3 = builder._tier3
-                    }
-                };
-            }
-        }
-
-        private class BcrFilterBuilder
-        {
-            private string[] _tier2;
-            private string[] _tier3;
-
-            public BcrFilterBuilder With(Criteria criteria, params string[] value)
-            {
-                switch (criteria)
-                {
-                    case Criteria.Tier2: return WithTier2(value);
-                    case Criteria.Tier3: return WithTier3(value);
-                    default: throw new NotSupportedException(criteria.ToString());
-                }
-            }
-            public BcrFilterBuilder WithTier2(params string[] tier2)
-            {
-                _tier2 = tier2;
-                return this;
-            }
-
-            public BcrFilterBuilder WithTier3(params string[] tier3)
-            {
-                _tier3 = tier3;
-                return this;
-            }
-
-            public BcrFilter Build()
-            {
-                return (BcrFilter)this;
-            }
-
-            public static implicit operator BcrFilter(BcrFilterBuilder builder)
-            {
-                return new BcrFilter(new BcrOptions(builder._tier2, builder._tier3));
-            }
         }
     }
 }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -32,12 +32,12 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }
 
-        [Test]
-        public void GivenNoTier2Option_ThenAllLinesShouldBeIncluded()
+        [TestCase(Criteria.Tier2)]
+        public void GivenNoTierOption_ThenAllLinesShouldBeIncluded(Criteria criteria)
         {
             var filter = A.BcrFilter().Build();
 
-            var bcr = new Bcr(new BcrLine[] { A.BcrLine().WithTier2("tier2") });
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().With(criteria, "tier") });
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Has.Count.EqualTo(1));
         }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -42,7 +42,7 @@ namespace Unit4.Automation.Tests
         }
 
         [TestCaseSource("CaseDifferences")]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised(Criteria criteria, string optionName)
+        public void GivenTheBcrCommand_ThenTheTierOptionShouldBeRecognised(Criteria criteria, string optionName)
         {
             var options = _parser.GetOptions("bcr", string.Format("--{0}=myTier", optionName));
             var bcrOptions = options as BcrOptions;

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -44,25 +44,32 @@ namespace Unit4.Automation.Tests
         }
 
         [TestCaseSource("CaseDifferences")]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised(string optionName)
+        public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised(Criteria criteria, string optionName)
         {
-            var options = _parser.GetOptions("bcr", string.Format("--{0}=00T2000", optionName));
+            var options = _parser.GetOptions("bcr", string.Format("--{0}=myTier", optionName));
             var bcrOptions = options as BcrOptions;
             
-            Assert.That(bcrOptions.ValueOf(Criteria.Tier2).Single(), Is.EqualTo("00T2000"));
+            Assert.That(bcrOptions.ValueOf(criteria).Single(), Is.EqualTo("myTier"));
         }
 
         private static IEnumerable<TestCaseData> CaseDifferences
         {
             get
             {
-                yield return new TestCaseData(Criteria.Tier2.Name().ToLowerInvariant());
-                yield return new TestCaseData(Criteria.Tier2.Name().ToUpperInvariant());
+                var criterias = (Criteria[])Enum.GetValues(typeof(Criteria));
+                foreach (var criteria in criterias)
+                {
+                    var lowerCase = criteria.Name().ToLowerInvariant();
+                    var upperCase = criteria.Name().ToUpperInvariant();
 
-                var stringBuilder = new StringBuilder(Criteria.Tier2.Name().Length);
-                stringBuilder.Append(Criteria.Tier2.Name().ToUpperInvariant().First());
-                var firstLetterCapitalised = Criteria.Tier2.Name().ToLowerInvariant().Skip(1).Aggregate(stringBuilder, (builder, c) => builder.Append(c)).ToString();
-                yield return new TestCaseData(firstLetterCapitalised);
+                    var stringBuilder = new StringBuilder(upperCase.Length);
+                    stringBuilder.Append(upperCase.First());
+                    var firstLetterCapitalised = lowerCase.Skip(1).Aggregate(stringBuilder, (builder, c) => builder.Append(c)).ToString();
+
+                    yield return new TestCaseData(criteria, lowerCase);
+                    yield return new TestCaseData(criteria, upperCase);
+                    yield return new TestCaseData(criteria, firstLetterCapitalised);
+                }
             }
         }
 

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -84,28 +84,15 @@ namespace Unit4.Automation.Tests
             Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(commandSeparatedTiers));
         }
 
-        [TestCaseSource("ExtraCommas")]
-        public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(Criteria criteria, string option)
+        [Test]
+        public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(
+            [Values] Criteria criteria, 
+            [Values("myTier,,,", ",myTier,,", ",,myTier,", ",,,myTier")] string option)
         {
             var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), option));
             var bcrOptions = options as BcrOptions;
 
             Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(new string[] { "myTier" }));
-        }
-
-        private static IEnumerable<TestCaseData> ExtraCommas
-        {
-            get
-            {
-                var criterias = (Criteria[])Enum.GetValues(typeof(Criteria));
-                foreach (var criteria in criterias)
-                {
-                    yield return new TestCaseData(criteria, "myTier,,,");
-                    yield return new TestCaseData(criteria, ",myTier,,");
-                    yield return new TestCaseData(criteria, ",,myTier,");
-                    yield return new TestCaseData(criteria, ",,,myTier");
-                }
-            }
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
 using Unit4.Automation.Tests.Helpers;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Unit4.Automation.Tests
 {
@@ -42,16 +43,27 @@ namespace Unit4.Automation.Tests
             Assert.That(_parser.GetOptions(command), Is.TypeOf(typeof(BcrOptions)));
         }
 
-        [TestCase("tier2")]
-        [TestCase("Tier2")]
-        [TestCase("TIER2")]
-        [TestCase("tIEr2")]
+        [TestCaseSource("CaseDifferences")]
         public void GivenTheBcrCommand_ThenTheTier2OptionShouldBeRecognised(string optionName)
         {
             var options = _parser.GetOptions("bcr", string.Format("--{0}=00T2000", optionName));
             var bcrOptions = options as BcrOptions;
             
             Assert.That(bcrOptions.ValueOf(Criteria.Tier2).Single(), Is.EqualTo("00T2000"));
+        }
+
+        private static IEnumerable<TestCaseData> CaseDifferences
+        {
+            get
+            {
+                yield return new TestCaseData(Criteria.Tier2.Name().ToLowerInvariant());
+                yield return new TestCaseData(Criteria.Tier2.Name().ToUpperInvariant());
+
+                var stringBuilder = new StringBuilder(Criteria.Tier2.Name().Length);
+                stringBuilder.Append(Criteria.Tier2.Name().ToUpperInvariant().First());
+                var firstLetterCapitalised = Criteria.Tier2.Name().ToLowerInvariant().Skip(1).Aggregate(stringBuilder, (builder, c) => builder.Append(c)).ToString();
+                yield return new TestCaseData(firstLetterCapitalised);
+            }
         }
 
         [TestCase(Criteria.Tier2)]

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using System.IO;
 using Unit4.Automation.Model;
 using System.Linq;
+using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
+using Unit4.Automation.Tests.Helpers;
 
 namespace Unit4.Automation.Tests
 {
@@ -48,7 +50,7 @@ namespace Unit4.Automation.Tests
             var options = _parser.GetOptions("bcr", string.Format("--{0}=00T2000", optionName));
             var bcrOptions = options as BcrOptions;
             
-            Assert.That(bcrOptions.Tier2.Single(), Is.EqualTo("00T2000"));
+            Assert.That(bcrOptions.ValueOf(Criteria.Tier2).Single(), Is.EqualTo("00T2000"));
         }
 
         [Test]
@@ -59,7 +61,7 @@ namespace Unit4.Automation.Tests
             var options = _parser.GetOptions("bcr", string.Format("--tier2={0}", string.Join(",", commandSeparatedTier2s)));
             var bcrOptions = options as BcrOptions;
 
-            Assert.That(bcrOptions.Tier2, Is.EquivalentTo(commandSeparatedTier2s));
+            Assert.That(bcrOptions.ValueOf(Criteria.Tier2), Is.EquivalentTo(commandSeparatedTier2s));
         }
 
         [TestCase("myTier2,,,")]
@@ -71,7 +73,7 @@ namespace Unit4.Automation.Tests
             var options = _parser.GetOptions("bcr", string.Format("--tier2={0}", option));
             var bcrOptions = options as BcrOptions;
 
-            Assert.That(bcrOptions.Tier2, Is.EquivalentTo(new string[] { "myTier2" }));
+            Assert.That(bcrOptions.ValueOf(Criteria.Tier2), Is.EquivalentTo(new string[] { "myTier2" }));
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -6,6 +6,7 @@ using Unit4.Automation.Model;
 using System.Linq;
 using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
 using Unit4.Automation.Tests.Helpers;
+using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests
 {
@@ -65,20 +66,28 @@ namespace Unit4.Automation.Tests
             Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(commandSeparatedTiers));
         }
 
-        [TestCase(Criteria.Tier2, "myTier,,,")]
-        [TestCase(Criteria.Tier2, ",myTier,,")]
-        [TestCase(Criteria.Tier2, ",,myTier,")]
-        [TestCase(Criteria.Tier2, ",,,myTier")]
-        [TestCase(Criteria.Tier3, "myTier,,,")]
-        [TestCase(Criteria.Tier3, ",myTier,,")]
-        [TestCase(Criteria.Tier3, ",,myTier,")]
-        [TestCase(Criteria.Tier3, ",,,myTier")]
+        [TestCaseSource("ExtraCommas")]
         public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(Criteria criteria, string option)
         {
             var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), option));
             var bcrOptions = options as BcrOptions;
 
             Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(new string[] { "myTier" }));
+        }
+
+        private static IEnumerable<TestCaseData> ExtraCommas
+        {
+            get
+            {
+                var criterias = (Criteria[])Enum.GetValues(typeof(Criteria));
+                foreach (var criteria in criterias)
+                {
+                    yield return new TestCaseData(criteria, "myTier,,,");
+                    yield return new TestCaseData(criteria, ",myTier,,");
+                    yield return new TestCaseData(criteria, ",,myTier,");
+                    yield return new TestCaseData(criteria, ",,,myTier");
+                }
+            }
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -58,7 +58,7 @@ namespace Unit4.Automation.Tests
         {
             var commandSeparatedTier2s = new string[] { "firstTier2", "secondTier2" };
             
-            var options = _parser.GetOptions("bcr", string.Format("--tier2={0}", string.Join(",", commandSeparatedTier2s)));
+            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", Criteria.Tier2.Name(), string.Join(",", commandSeparatedTier2s)));
             var bcrOptions = options as BcrOptions;
 
             Assert.That(bcrOptions.ValueOf(Criteria.Tier2), Is.EquivalentTo(commandSeparatedTier2s));
@@ -70,7 +70,7 @@ namespace Unit4.Automation.Tests
         [TestCase(",,,myTier2")]
         public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(string option)
         {
-            var options = _parser.GetOptions("bcr", string.Format("--tier2={0}", option));
+            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", Criteria.Tier2.Name(), option));
             var bcrOptions = options as BcrOptions;
 
             Assert.That(bcrOptions.ValueOf(Criteria.Tier2), Is.EquivalentTo(new string[] { "myTier2" }));

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -73,9 +73,8 @@ namespace Unit4.Automation.Tests
             }
         }
 
-        [TestCase(Criteria.Tier2)]
-        [TestCase(Criteria.Tier3)]
-        public void GivenTheBcrCommand_ThenTheTierOptionShouldTakeCommaSeparatedValues(Criteria criteria)
+        [Test]
+        public void GivenTheBcrCommand_ThenTheTierOptionShouldTakeCommaSeparatedValues([Values]Criteria criteria)
         {
             var commandSeparatedTiers = new string[] { "firstTier2", "secondTier2" };
             

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -65,16 +65,20 @@ namespace Unit4.Automation.Tests
             Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(commandSeparatedTiers));
         }
 
-        [TestCase("myTier2,,,")]
-        [TestCase(",myTier2,,")]
-        [TestCase(",,myTier2,")]
-        [TestCase(",,,myTier2")]
-        public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(string option)
+        [TestCase(Criteria.Tier2, "myTier,,,")]
+        [TestCase(Criteria.Tier2, ",myTier,,")]
+        [TestCase(Criteria.Tier2, ",,myTier,")]
+        [TestCase(Criteria.Tier2, ",,,myTier")]
+        [TestCase(Criteria.Tier3, "myTier,,,")]
+        [TestCase(Criteria.Tier3, ",myTier,,")]
+        [TestCase(Criteria.Tier3, ",,myTier,")]
+        [TestCase(Criteria.Tier3, ",,,myTier")]
+        public void GivenTheBcrCommand_ThenExtraCommasShouldBeIgnored(Criteria criteria, string option)
         {
-            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", Criteria.Tier2.Name(), option));
+            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), option));
             var bcrOptions = options as BcrOptions;
 
-            Assert.That(bcrOptions.ValueOf(Criteria.Tier2), Is.EquivalentTo(new string[] { "myTier2" }));
+            Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(new string[] { "myTier" }));
         }
     }
 }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -34,11 +34,9 @@ namespace Unit4.Automation.Tests
             Assert.That(_parser.GetOptions("unknown"), Is.TypeOf(typeof(NullOptions)));
         }
 
-        [TestCase("bcr")]
-        [TestCase("BCR")]
-        [TestCase("BcR")]
-        [TestCase("Bcr")]
-        public void GivenTheBcrCommandInAnyCase_ThenTheCommandShouldBeBcr(string command)
+        [Test]
+        public void GivenTheBcrCommandInAnyCase_ThenTheCommandShouldBeBcr(
+            [Values("bcr", "BCR", "BcR", "Bcr")] string command)
         {
             Assert.That(_parser.GetOptions(command), Is.TypeOf(typeof(BcrOptions)));
         }

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -76,7 +76,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTheBcrCommand_ThenTheTierOptionShouldTakeCommaSeparatedValues([Values]Criteria criteria)
         {
-            var commandSeparatedTiers = new string[] { "firstTier2", "secondTier2" };
+            var commandSeparatedTiers = new string[] { "firstTier", "secondTier" };
             
             var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), string.Join(",", commandSeparatedTiers)));
             var bcrOptions = options as BcrOptions;

--- a/Unit4/Tests/CommandParserTests.cs
+++ b/Unit4/Tests/CommandParserTests.cs
@@ -10,7 +10,7 @@ using Unit4.Automation.Tests.Helpers;
 namespace Unit4.Automation.Tests
 {
     [TestFixture]
-    public class CommandParserTests
+    internal class CommandParserTests
     {
         private CommandParser<BcrOptions> _parser;
 
@@ -53,15 +53,16 @@ namespace Unit4.Automation.Tests
             Assert.That(bcrOptions.ValueOf(Criteria.Tier2).Single(), Is.EqualTo("00T2000"));
         }
 
-        [Test]
-        public void GivenTheBcrCommand_ThenTheTier2OptionShouldTakeCommaSeparatedValues()
+        [TestCase(Criteria.Tier2)]
+        [TestCase(Criteria.Tier3)]
+        public void GivenTheBcrCommand_ThenTheTierOptionShouldTakeCommaSeparatedValues(Criteria criteria)
         {
-            var commandSeparatedTier2s = new string[] { "firstTier2", "secondTier2" };
+            var commandSeparatedTiers = new string[] { "firstTier2", "secondTier2" };
             
-            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", Criteria.Tier2.Name(), string.Join(",", commandSeparatedTier2s)));
+            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), string.Join(",", commandSeparatedTiers)));
             var bcrOptions = options as BcrOptions;
 
-            Assert.That(bcrOptions.ValueOf(Criteria.Tier2), Is.EquivalentTo(commandSeparatedTier2s));
+            Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(commandSeparatedTiers));
         }
 
         [TestCase("myTier2,,,")]

--- a/Unit4/Tests/Helpers/A.cs
+++ b/Unit4/Tests/Helpers/A.cs
@@ -1,5 +1,6 @@
 using System;
 using Unit4.Automation.Model;
+using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests.Helpers
 {
@@ -15,6 +16,16 @@ namespace Unit4.Automation.Tests.Helpers
         public static BcrFilterBuilder BcrFilter()
         {
             return new BcrFilterBuilder();
+        }
+
+        public static IEnumerable<string> ValueOf(this BcrOptions options, Criteria criteria)
+        {
+            switch (criteria)
+            {
+                case Criteria.Tier2: return options.Tier2;
+                case Criteria.Tier3: return options.Tier3;
+                default: throw new NotSupportedException(criteria.ToString());
+            }
         }
     }
 }

--- a/Unit4/Tests/Helpers/A.cs
+++ b/Unit4/Tests/Helpers/A.cs
@@ -1,0 +1,20 @@
+using System;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Tests.Helpers
+{
+    internal static class A
+    {
+        public enum Criteria { Tier2, Tier3 }
+
+        public static BcrLineBuilder BcrLine()
+        {
+            return new BcrLineBuilder();
+        }
+
+        public static BcrFilterBuilder BcrFilter()
+        {
+            return new BcrFilterBuilder();
+        }
+    }
+}

--- a/Unit4/Tests/Helpers/A.cs
+++ b/Unit4/Tests/Helpers/A.cs
@@ -27,5 +27,15 @@ namespace Unit4.Automation.Tests.Helpers
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }
+
+        public static string Name(this Criteria criteria)
+        {
+            switch (criteria)
+            {
+                case Criteria.Tier2: return "tier2";
+                case Criteria.Tier3: return "tier3";
+                default: throw new NotSupportedException(criteria.ToString());
+            }
+        }
     }
 }

--- a/Unit4/Tests/Helpers/BcrFilterBuilder.cs
+++ b/Unit4/Tests/Helpers/BcrFilterBuilder.cs
@@ -1,0 +1,43 @@
+using System;
+using Unit4.Automation.Model;
+using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
+
+namespace Unit4.Automation.Tests.Helpers
+{
+    internal class BcrFilterBuilder
+    {
+        private string[] _tier2;
+        private string[] _tier3;
+
+        public BcrFilterBuilder With(Criteria criteria, params string[] value)
+        {
+            switch (criteria)
+            {
+                case Criteria.Tier2: return WithTier2(value);
+                case Criteria.Tier3: return WithTier3(value);
+                default: throw new NotSupportedException(criteria.ToString());
+            }
+        }
+        public BcrFilterBuilder WithTier2(params string[] tier2)
+        {
+            _tier2 = tier2;
+            return this;
+        }
+
+        public BcrFilterBuilder WithTier3(params string[] tier3)
+        {
+            _tier3 = tier3;
+            return this;
+        }
+
+        public BcrFilter Build()
+        {
+            return (BcrFilter)this;
+        }
+
+        public static implicit operator BcrFilter(BcrFilterBuilder builder)
+        {
+            return new BcrFilter(new BcrOptions(builder._tier2, builder._tier3));
+        }
+    }
+}

--- a/Unit4/Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4/Tests/Helpers/BcrLineBuilder.cs
@@ -1,0 +1,49 @@
+using System;
+using Unit4.Automation.Model;
+using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
+
+namespace Unit4.Automation.Tests.Helpers
+{
+    internal class BcrLineBuilder
+    {
+        private string _tier2;
+        private string _tier3;
+        
+        public BcrLineBuilder With(Criteria criteria, string value)
+        {
+            switch (criteria)
+            {
+                case Criteria.Tier2: return WithTier2(value);
+                case Criteria.Tier3: return WithTier3(value);
+                default: throw new NotSupportedException(criteria.ToString());
+            }
+        }
+
+        public BcrLineBuilder WithTier2(string tier2)
+        {
+            _tier2 = tier2;
+            return this;
+        }
+
+        public BcrLineBuilder WithTier3(string tier3)
+        {
+            _tier3 = tier3;
+            return this;
+        }
+
+        public BcrLine Build()
+        {
+            return (BcrLine)this;
+        }
+
+        public static implicit operator BcrLine(BcrLineBuilder builder)
+        {
+            return new BcrLine() {
+                CostCentre = new CostCentre() {
+                    Tier2 = builder._tier2,
+                    Tier3 = builder._tier3
+                }
+            };
+        }
+    }
+}

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -124,6 +124,9 @@
     <Compile Include="Interfaces\IBcrReader.cs" />
     <Compile Include="Interfaces\IBcrWriter.cs" />
     <Compile Include="Interfaces\IBcrMiddleware.cs" />
+    <Compile Include="Tests\Helpers\A.cs" />
+    <Compile Include="Tests\Helpers\BcrLineBuilder.cs" />
+    <Compile Include="Tests\Helpers\BcrFilterBuilder.cs" />
     <Compile Include="Tests\Unit4WebProviderTests.cs" />
     <Compile Include="Tests\ExcelTests.cs" />
     <Compile Include="Tests\CostCentreHierarchyTests.cs" />

--- a/build-tools.psm1
+++ b/build-tools.psm1
@@ -13,8 +13,9 @@ function Test {
     & ".\packages\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe" .\Unit4\bin\Debug\unit4-automation.exe
 }
 
-function Run([String[]] $options = "") {
-    & ".\Unit4\bin\Debug\unit4-automation.exe" bcr $options
+function Run([string[]][parameter(ValueFromRemainingArguments)] $options = "") {
+    $arguments = $options | ForEach-Object { $_ -Replace " ", "," }
+    & ".\Unit4\bin\Debug\unit4-automation.exe" bcr $arguments
 }
 
 function Help {


### PR DESCRIPTION
This lets you specify a `tier3` option to the `bcr` command.

It's tested in the same way as the `tier2` option.

The `tier2` and `tier3` options are a disjunction (an OR statement) - a match against either will return a line.

This is tested in `BcrFilterTests`, where we effectively test the OR truth table.