### PR TITLE
Add a tier4 option to the bcr command

### DIFF
--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -15,11 +15,6 @@ namespace Unit4.Automation
 
         public Bcr Use(Bcr bcr)
         {
-            if (_options.Tier2 == null)
-            {
-                return bcr;
-            }
-
             return new Bcr(bcr.Lines.Where(x => Matches(x.CostCentre)).ToList());
         }
 

--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -25,18 +25,20 @@ namespace Unit4.Automation
 
         private bool Matches(CostCentre costCentre)
         {
-            if (!HasTier2 && !HasTier3)
+            if (!HasTier2 && !HasTier3 && !HasTier4)
             {
                 return true;
             }
 
             var matchesTier2 = HasTier2 && MatchesTier2(costCentre);
             var matchesTier3 = HasTier3 && MatchesTier3(costCentre);
-            return matchesTier2 || matchesTier3;
+            var matchesTier4 = HasTier4 && MatchesTier4(costCentre);
+            return matchesTier2 || matchesTier3 || matchesTier4;
         }
 
         private bool HasTier2 { get { return _options.Tier2 != null && _options.Tier2.Any(); } }
         private bool HasTier3 { get { return _options.Tier3 != null && _options.Tier3.Any(); } }
+        private bool HasTier4 { get { return _options.Tier4 != null && _options.Tier4.Any(); } }
 
         private bool MatchesTier2(CostCentre costCentre)
         {
@@ -46,6 +48,11 @@ namespace Unit4.Automation
         private bool MatchesTier3(CostCentre costCentre)
         {
             return _options.Tier3.Any(x => string.Equals(x, costCentre.Tier3));
+        }
+
+        private bool MatchesTier4(CostCentre costCentre)
+        {
+            return _options.Tier4.Any(x => string.Equals(x, costCentre.Tier4));
         }
     }
 }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -11,10 +11,15 @@ namespace Unit4.Automation.Model
         private readonly IEnumerable<string> _tier2;
         private readonly IEnumerable<string> _tier3;
 
-        public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>())
+        public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {}
 
         public BcrOptions(IEnumerable<string> tier2, IEnumerable<string> tier3)
+            : this(tier2, tier3, Enumerable.Empty<string>())
+        {
+        }
+
+        public BcrOptions(IEnumerable<string> tier2, IEnumerable<string> tier3, IEnumerable<string> tier4)
         {
             _tier2 = tier2;
             _tier3 = tier3;
@@ -45,6 +50,14 @@ namespace Unit4.Automation.Model
                 }
 
                 return _tier3.Where(x => !string.Equals(x, string.Empty));
+            }
+        }
+
+        public IEnumerable<string> Tier4
+        {
+            get
+            {
+                throw new System.NotSupportedException();
             }
         }
     }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -10,19 +10,16 @@ namespace Unit4.Automation.Model
     {
         private readonly IEnumerable<string> _tier2;
         private readonly IEnumerable<string> _tier3;
+        private readonly IEnumerable<string> _tier4;
 
         public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {}
-
-        public BcrOptions(IEnumerable<string> tier2, IEnumerable<string> tier3)
-            : this(tier2, tier3, Enumerable.Empty<string>())
-        {
-        }
 
         public BcrOptions(IEnumerable<string> tier2, IEnumerable<string> tier3, IEnumerable<string> tier4)
         {
             _tier2 = tier2;
             _tier3 = tier3;
+            _tier4 = tier4;
         }
 
         [Option(HelpText = "Filter by a tier 2 code.", Separator=',')]
@@ -53,11 +50,17 @@ namespace Unit4.Automation.Model
             }
         }
 
+        [Option(HelpText = "Filter by a tier 4 code.", Separator=',')]
         public IEnumerable<string> Tier4
         {
             get
             {
-                throw new System.NotSupportedException();
+                if (_tier4 == null)
+                {
+                    return Enumerable.Empty<string>();
+                }
+
+                return _tier4.Where(x => !string.Equals(x, string.Empty));
             }
         }
     }

--- a/Unit4/Tests/BcrFilterTests.cs
+++ b/Unit4/Tests/BcrFilterTests.cs
@@ -57,9 +57,8 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { firstBcrLine, secondBcrLine }));
         }
 
-        [Test]
-        public void GivenMatchOnAtLeastOneTier_ThenTheLineShouldBeIncluded(
-            [ValueSource("CriteriaPowerset")] IEnumerable<Criteria> criteria)
+        [Test, TestCaseSource("CriteriaPowerset")]
+        public void GivenMatchOnAtLeastOneTier_ThenTheLineShouldBeIncluded(IEnumerable<Criteria> criteria)
         {
             var tiers = (Criteria[])Enum.GetValues(typeof(Criteria));
 
@@ -74,11 +73,15 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new BcrLine[] { bcrLine }));
         }
 
-        private static IEnumerable<IEnumerable<Criteria>> CriteriaPowerset
+        private static IEnumerable<TestCaseData> CriteriaPowerset
         {
             get
             {
-                return Enum.GetValues(typeof(Criteria)).Cast<Criteria>().Powerset().Where(x => x.Any());
+                return Enum.GetValues(typeof(Criteria))
+                            .Cast<Criteria>()
+                            .Powerset()
+                            .Where(x => x.Any())
+                            .Select(x => new TestCaseData(x).SetName("{M}(" + string.Join(",", x.ToArray()) + ")"));
             }
         }
 

--- a/Unit4/Tests/Helpers/A.cs
+++ b/Unit4/Tests/Helpers/A.cs
@@ -6,7 +6,7 @@ namespace Unit4.Automation.Tests.Helpers
 {
     internal static class A
     {
-        public enum Criteria { Tier2, Tier3 }
+        public enum Criteria { Tier2, Tier3, Tier4 }
 
         public static BcrLineBuilder BcrLine()
         {
@@ -24,6 +24,7 @@ namespace Unit4.Automation.Tests.Helpers
             {
                 case Criteria.Tier2: return options.Tier2;
                 case Criteria.Tier3: return options.Tier3;
+                case Criteria.Tier4: return options.Tier4;
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }
@@ -34,6 +35,7 @@ namespace Unit4.Automation.Tests.Helpers
             {
                 case Criteria.Tier2: return "tier2";
                 case Criteria.Tier3: return "tier3";
+                case Criteria.Tier4: return "tier4";
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }

--- a/Unit4/Tests/Helpers/BcrFilterBuilder.cs
+++ b/Unit4/Tests/Helpers/BcrFilterBuilder.cs
@@ -8,6 +8,7 @@ namespace Unit4.Automation.Tests.Helpers
     {
         private string[] _tier2;
         private string[] _tier3;
+        private string[] _tier4;
 
         public BcrFilterBuilder With(Criteria criteria, params string[] value)
         {
@@ -15,6 +16,7 @@ namespace Unit4.Automation.Tests.Helpers
             {
                 case Criteria.Tier2: return WithTier2(value);
                 case Criteria.Tier3: return WithTier3(value);
+                case Criteria.Tier4: return WithTier4(value);
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }
@@ -30,6 +32,12 @@ namespace Unit4.Automation.Tests.Helpers
             return this;
         }
 
+        public BcrFilterBuilder WithTier4(params string[] tier4)
+        {
+            _tier4 = tier4;
+            return this;
+        }
+
         public BcrFilter Build()
         {
             return (BcrFilter)this;
@@ -37,7 +45,7 @@ namespace Unit4.Automation.Tests.Helpers
 
         public static implicit operator BcrFilter(BcrFilterBuilder builder)
         {
-            return new BcrFilter(new BcrOptions(builder._tier2, builder._tier3));
+            return new BcrFilter(new BcrOptions(builder._tier2, builder._tier3, builder._tier4));
         }
     }
 }

--- a/Unit4/Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4/Tests/Helpers/BcrLineBuilder.cs
@@ -8,6 +8,7 @@ namespace Unit4.Automation.Tests.Helpers
     {
         private string _tier2;
         private string _tier3;
+        private string _tier4;
         
         public BcrLineBuilder With(Criteria criteria, string value)
         {
@@ -15,6 +16,7 @@ namespace Unit4.Automation.Tests.Helpers
             {
                 case Criteria.Tier2: return WithTier2(value);
                 case Criteria.Tier3: return WithTier3(value);
+                case Criteria.Tier4: return WithTier4(value);
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }
@@ -31,6 +33,12 @@ namespace Unit4.Automation.Tests.Helpers
             return this;
         }
 
+        public BcrLineBuilder WithTier4(string tier4)
+        {
+            _tier4 = tier4;
+            return this;
+        }
+
         public BcrLine Build()
         {
             return (BcrLine)this;
@@ -41,7 +49,8 @@ namespace Unit4.Automation.Tests.Helpers
             return new BcrLine() {
                 CostCentre = new CostCentre() {
                     Tier2 = builder._tier2,
-                    Tier3 = builder._tier3
+                    Tier3 = builder._tier3,
+                    Tier4 = builder._tier4,
                 }
             };
         }

--- a/build-tools.psm1
+++ b/build-tools.psm1
@@ -13,11 +13,6 @@ function Test {
     & ".\packages\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe" .\Unit4\bin\Debug\unit4-automation.exe
 }
 
-function Run([string[]][parameter(ValueFromRemainingArguments)] $options = "") {
-    $arguments = $options | ForEach-Object { $_ -Replace " ", "," }
-    & ".\Unit4\bin\Debug\unit4-automation.exe" bcr $arguments
-}
-
 function Help {
     & ".\Unit4\bin\Debug\unit4-automation.exe" help
 }


### PR DESCRIPTION
This adds a `--tier4=` option to the `bcr` command.

It works in the same way as tier2 and tier3, and has all the same tests.