### PR TITLE
Add a costcentre option to the bcr command

### DIFF
--- a/Unit4/BcrFilter.cs
+++ b/Unit4/BcrFilter.cs
@@ -21,7 +21,7 @@ namespace Unit4.Automation
 
         private bool Matches(CostCentre costCentre)
         {
-            if (!HasOption(_options.Tier1) && !HasOption(_options.Tier2) && !HasOption(_options.Tier3) && !HasOption(_options.Tier4))
+            if (!HasOption(_options.Tier1) && !HasOption(_options.Tier2) && !HasOption(_options.Tier3) && !HasOption(_options.Tier4) && !HasOption(_options.CostCentre))
             {
                 return true;
             }
@@ -30,7 +30,8 @@ namespace Unit4.Automation
             var matchesTier2 = HasOption(_options.Tier2) && Matches(_options.Tier2, costCentre.Tier2);
             var matchesTier3 = HasOption(_options.Tier3) && Matches(_options.Tier3, costCentre.Tier3);
             var matchesTier4 = HasOption(_options.Tier4) && Matches(_options.Tier4, costCentre.Tier4);
-            return matchesTier1 || matchesTier2 || matchesTier3 || matchesTier4;
+            var matchesCostCentre = HasOption(_options.CostCentre) && Matches(_options.CostCentre, costCentre.Code);
+            return matchesTier1 || matchesTier2 || matchesTier3 || matchesTier4 || matchesCostCentre;
         }
 
         private bool HasOption(IEnumerable<string> option)

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -12,14 +12,10 @@ namespace Unit4.Automation.Model
         private readonly IEnumerable<string> _tier2;
         private readonly IEnumerable<string> _tier3;
         private readonly IEnumerable<string> _tier4;
+        private readonly IEnumerable<string> _costCentre;
 
         public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {}
-
-        public BcrOptions(IEnumerable<string> tier1, IEnumerable<string> tier2, IEnumerable<string> tier3, IEnumerable<string> tier4)
-            : this(tier1, tier2, tier3, tier4, Enumerable.Empty<string>())
-        {
-        }
 
         public BcrOptions(IEnumerable<string> tier1, IEnumerable<string> tier2, IEnumerable<string> tier3, IEnumerable<string> tier4, IEnumerable<string> costCentre)
         {
@@ -27,6 +23,7 @@ namespace Unit4.Automation.Model
             _tier2 = tier2;
             _tier3 = tier3;
             _tier4 = tier4;
+            _costCentre = costCentre;
         }
 
         [Option(HelpText = "Filter by a tier 1 code.", Separator=',')]
@@ -65,11 +62,12 @@ namespace Unit4.Automation.Model
             }
         }
 
+        [Option(HelpText = "Filter by a cost centre.", Separator=',')]
         public IEnumerable<string> CostCentre
         {
             get
             {
-                throw new System.NotSupportedException();
+                return PreventNullAndRemoveEmptyStrings(_costCentre);
             }
         }
 

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -13,10 +13,15 @@ namespace Unit4.Automation.Model
         private readonly IEnumerable<string> _tier3;
         private readonly IEnumerable<string> _tier4;
 
-        public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>())
+        public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {}
 
         public BcrOptions(IEnumerable<string> tier1, IEnumerable<string> tier2, IEnumerable<string> tier3, IEnumerable<string> tier4)
+            : this(tier1, tier2, tier3, tier4, Enumerable.Empty<string>())
+        {
+        }
+
+        public BcrOptions(IEnumerable<string> tier1, IEnumerable<string> tier2, IEnumerable<string> tier3, IEnumerable<string> tier4, IEnumerable<string> costCentre)
         {
             _tier1 = tier1;
             _tier2 = tier2;
@@ -57,6 +62,14 @@ namespace Unit4.Automation.Model
             get
             {
                 return PreventNullAndRemoveEmptyStrings(_tier4);
+            }
+        }
+
+        public IEnumerable<string> CostCentre
+        {
+            get
+            {
+                throw new System.NotSupportedException();
             }
         }
 

--- a/Unit4/Tests/Helpers/A.cs
+++ b/Unit4/Tests/Helpers/A.cs
@@ -6,7 +6,7 @@ namespace Unit4.Automation.Tests.Helpers
 {
     internal static class A
     {
-        public enum Criteria { Tier1, Tier2, Tier3, Tier4 }
+        public enum Criteria { Tier1, Tier2, Tier3, Tier4, CostCentre }
 
         public static BcrLineBuilder BcrLine()
         {
@@ -26,6 +26,7 @@ namespace Unit4.Automation.Tests.Helpers
                 case Criteria.Tier2: return options.Tier2;
                 case Criteria.Tier3: return options.Tier3;
                 case Criteria.Tier4: return options.Tier4;
+                case Criteria.CostCentre: return options.CostCentre;
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }
@@ -38,6 +39,7 @@ namespace Unit4.Automation.Tests.Helpers
                 case Criteria.Tier2: return "tier2";
                 case Criteria.Tier3: return "tier3";
                 case Criteria.Tier4: return "tier4";
+                case Criteria.CostCentre: return "costcentre";
                 default: throw new NotSupportedException(criteria.ToString());
             }
         }

--- a/Unit4/Tests/Helpers/BcrFilterBuilder.cs
+++ b/Unit4/Tests/Helpers/BcrFilterBuilder.cs
@@ -10,6 +10,7 @@ namespace Unit4.Automation.Tests.Helpers
         private string[] _tier2;
         private string[] _tier3;
         private string[] _tier4;
+        private string[] _costCentre;
 
         public BcrFilterBuilder With(Criteria criteria, params string[] value)
         {
@@ -19,6 +20,7 @@ namespace Unit4.Automation.Tests.Helpers
                 case Criteria.Tier2: _tier2 = value; break;
                 case Criteria.Tier3: _tier3 = value; break;
                 case Criteria.Tier4: _tier4 = value; break;
+                case Criteria.CostCentre: _costCentre = value; break;
                 default: throw new NotSupportedException(criteria.ToString());
             }
 
@@ -32,7 +34,7 @@ namespace Unit4.Automation.Tests.Helpers
 
         public static implicit operator BcrFilter(BcrFilterBuilder builder)
         {
-            return new BcrFilter(new BcrOptions(builder._tier1, builder._tier2, builder._tier3, builder._tier4));
+            return new BcrFilter(new BcrOptions(builder._tier1, builder._tier2, builder._tier3, builder._tier4, builder._costCentre));
         }
     }
 }

--- a/Unit4/Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4/Tests/Helpers/BcrLineBuilder.cs
@@ -10,6 +10,7 @@ namespace Unit4.Automation.Tests.Helpers
         private string _tier2;
         private string _tier3;
         private string _tier4;
+        private string _costCentre;
         
         public BcrLineBuilder With(Criteria criteria, string value)
         {
@@ -19,6 +20,7 @@ namespace Unit4.Automation.Tests.Helpers
                 case Criteria.Tier2: _tier2 = value; break;
                 case Criteria.Tier3: _tier3 = value; break;
                 case Criteria.Tier4: _tier4 = value; break;
+                case Criteria.CostCentre: _costCentre = value; break;
                 default: throw new NotSupportedException(criteria.ToString());
             }
 
@@ -38,6 +40,7 @@ namespace Unit4.Automation.Tests.Helpers
                     Tier2 = builder._tier2,
                     Tier3 = builder._tier3,
                     Tier4 = builder._tier4,
+                    Code = builder._costCentre,
                 }
             };
         }


### PR DESCRIPTION
This adds a `costcentre` option to the `bcr` command.

It works in the same way as the other tiers, and has the same tests.