### PR TITLE
Use the SOAP service url, username and client from the registry first

### DIFF
--- a/Unit4/ReportEngine/Unit4WebConnector.cs
+++ b/Unit4/ReportEngine/Unit4WebConnector.cs
@@ -26,14 +26,28 @@ namespace Unit4.Automation.ReportEngine
             { 
                 Name = "WebService",
                 Authenticators = authenticators,
-                Authenticator = agressoAuthenticator,
-                Datasource = m_Credentials.SoapService
             };
-            
-            agressoAuthenticator.Name = m_Credentials.Username;
-            agressoAuthenticator.Client = m_Credentials.Client;
+
+            connector.Read();
+            connector.Authenticator = agressoAuthenticator;
+
+            SetCredentialsIfNotFoundFromRegistry(connector, agressoAuthenticator);
 
             return connector;
+        }
+
+        private void SetCredentialsIfNotFoundFromRegistry(WebProviderConnector connector, AgressoAuthenticator agressoAuthenticator)
+        {
+            if (string.IsNullOrEmpty(connector.Datasource))
+            {
+                connector.Datasource = m_Credentials.SoapService;
+            }
+
+            if (string.IsNullOrEmpty(agressoAuthenticator.Name))
+            {
+                agressoAuthenticator.Name = m_Credentials.Username;
+                agressoAuthenticator.Client = m_Credentials.Client;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #9 

When you log in to Excelerator, the SOAP service url, username and client all get saved in the registry.

`connector.Read()` loads all of these. Let's use it if we can, and fallback to our `Credentials` class if anything isn't set.

Not really got a great way to test this other than verifying method calls. That doesn't seem particularly valuable, since it'll be fairly obvious if this isn't working.