### PR TITLE
Use C# 6, clean up code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ Installer.wixobj
 Installer.msi
 Installer.wixpdb
 config.json
+InspectCodeReport.Html

--- a/.gitignore
+++ b/.gitignore
@@ -341,4 +341,4 @@ Installer.wixobj
 Installer.msi
 Installer.wixpdb
 config.json
-InspectCodeReport.Html
+InspectCodeReport.html

--- a/Unit4.Automation.Tests/BcrFilterTests.cs
+++ b/Unit4.Automation.Tests/BcrFilterTests.cs
@@ -55,7 +55,7 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new [] { firstBcrLine, secondBcrLine }));
         }
 
-        [Test, TestCaseSource("CriteriaPowerset")]
+        [Test, TestCaseSource(nameof(CriteriaPowerset)]
         public void GivenMatchOnAtLeastOneTier_ThenTheLineShouldBeIncluded(IEnumerable<Criteria> criteria)
         {
             var tiers = (Criteria[])Enum.GetValues(typeof(Criteria));

--- a/Unit4.Automation.Tests/BcrFilterTests.cs
+++ b/Unit4.Automation.Tests/BcrFilterTests.cs
@@ -55,7 +55,7 @@ namespace Unit4.Automation.Tests
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.EquivalentTo(new [] { firstBcrLine, secondBcrLine }));
         }
 
-        [Test, TestCaseSource(nameof(CriteriaPowerset)]
+        [Test, TestCaseSource(nameof(CriteriaPowerset))]
         public void GivenMatchOnAtLeastOneTier_ThenTheLineShouldBeIncluded(IEnumerable<Criteria> criteria)
         {
             var tiers = (Criteria[])Enum.GetValues(typeof(Criteria));

--- a/Unit4.Automation.Tests/BcrReportRunnerTests.cs
+++ b/Unit4.Automation.Tests/BcrReportRunnerTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Moq;
 using System.IO;
 using System.Linq;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/BcrReportTests.cs
+++ b/Unit4.Automation.Tests/BcrReportTests.cs
@@ -90,7 +90,7 @@ namespace Unit4.Automation.Tests
         {
             private readonly Mock<IUnit4Engine> _mock;
 
-            public Mock<IUnit4Engine> Mock { get { return _mock; } }
+            public Mock<IUnit4Engine> Mock => _mock;
 
             public DummyEngineFactory(IEnumerable<string> returnEmpty, IEnumerable<string> throws = null)
             {
@@ -109,15 +109,12 @@ namespace Unit4.Automation.Tests
                 return dataset;
             }
 
-            public IUnit4Engine Create()
-            {
-                return _mock.Object;
-            }
+            public IUnit4Engine Create() =>  _mock.Object;
         }
 
         private class NullLogging : ILogging
         {
-            public string Path { get { return string.Empty; } }
+            public string Path => string.Empty;
 
             public void Start() {}
             public void Close() {}

--- a/Unit4.Automation.Tests/BcrReportTests.cs
+++ b/Unit4.Automation.Tests/BcrReportTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using System.Collections.Generic;
 using System.Linq;
 using Unit4.Automation.Model;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/ConfigRunnerTests.cs
+++ b/Unit4.Automation.Tests/ConfigRunnerTests.cs
@@ -1,6 +1,4 @@
-using System;
 using Unit4.Automation.Model;
-using Unit4.Automation;
 using NUnit.Framework;
 using Unit4.Automation.Tests.Helpers;
 using Unit4.Automation.Commands.ConfigCommand;

--- a/Unit4.Automation.Tests/ConfigRunnerTests.cs
+++ b/Unit4.Automation.Tests/ConfigRunnerTests.cs
@@ -3,6 +3,7 @@ using Unit4.Automation.Model;
 using Unit4.Automation;
 using NUnit.Framework;
 using Unit4.Automation.Tests.Helpers;
+using Unit4.Automation.Commands.ConfigCommand;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/ExcelTests.cs
+++ b/Unit4.Automation.Tests/ExcelTests.cs
@@ -1,4 +1,3 @@
-using System;
 using NUnit.Framework;
 using Unit4.Automation.Model;
 using System.Linq;

--- a/Unit4.Automation.Tests/Helpers/A.cs
+++ b/Unit4.Automation.Tests/Helpers/A.cs
@@ -8,15 +8,9 @@ namespace Unit4.Automation.Tests.Helpers
     {
         public enum Criteria { Tier1, Tier2, Tier3, Tier4, CostCentre }
 
-        public static BcrLineBuilder BcrLine()
-        {
-            return new BcrLineBuilder();
-        }
+        public static BcrLineBuilder BcrLine() => new BcrLineBuilder();
 
-        public static BcrFilterBuilder BcrFilter()
-        {
-            return new BcrFilterBuilder();
-        }
+        public static BcrFilterBuilder BcrFilter() => new BcrFilterBuilder();
 
         public static IEnumerable<string> ValueOf(this BcrOptions options, Criteria criteria)
         {

--- a/Unit4.Automation.Tests/Helpers/BcrFilterBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrFilterBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using Unit4.Automation.Model;
 using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests.Helpers
 {

--- a/Unit4.Automation.Tests/Helpers/BcrFilterBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrFilterBuilder.cs
@@ -28,10 +28,7 @@ namespace Unit4.Automation.Tests.Helpers
             return this;
         }
 
-        public BcrFilter Build()
-        {
-            return this;
-        }
+        public BcrFilter Build() => this;
 
         public static implicit operator BcrFilter(BcrFilterBuilder builder)
         {

--- a/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
@@ -27,10 +27,7 @@ namespace Unit4.Automation.Tests.Helpers
             return this;
         }
 
-        public BcrLine Build()
-        {
-            return this;
-        }
+        public BcrLine Build() => this;
 
         public static implicit operator BcrLine(BcrLineBuilder builder)
         {

--- a/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
@@ -1,7 +1,6 @@
 using System;
 using Unit4.Automation.Model;
 using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
-using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests.Helpers
 {

--- a/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using Unit4.Automation.Model;
 using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests.Helpers
 {

--- a/Unit4.Automation.Tests/Helpers/TempFile.cs
+++ b/Unit4.Automation.Tests/Helpers/TempFile.cs
@@ -7,7 +7,7 @@ namespace Unit4.Automation.Tests.Helpers
     {
         private readonly string _path;
 
-        public string Path { get { return _path; } }
+        public string Path => _path;
         
         public TempFile(string extension)
         {

--- a/Unit4.Automation.Tests/Helpers/TempFile.cs
+++ b/Unit4.Automation.Tests/Helpers/TempFile.cs
@@ -13,7 +13,7 @@ namespace Unit4.Automation.Tests.Helpers
         {
             var tempDirectory = System.IO.Path.GetTempPath();
 
-            var fileName = string.Format("{0}.{1}", Guid.NewGuid().ToString("N"), extension);
+            var fileName = $"{Guid.NewGuid().ToString("N")}.{extension}";
 
             _path = System.IO.Path.Combine(tempDirectory, fileName);
         }

--- a/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
@@ -7,6 +7,7 @@ using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
 using Unit4.Automation.Tests.Helpers;
 using System.Collections.Generic;
 using System.Text;
+using Unit4.Automation.Commands;
 
 namespace Unit4.Automation.Tests.Parser
 {

--- a/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
@@ -32,7 +32,7 @@ namespace Unit4.Automation.Tests.Parser
         [TestCaseSource("CaseDifferences")]
         public void GivenTheBcrCommand_ThenTheTierOptionShouldBeRecognised(Criteria criteria, string optionName)
         {
-            var options = _parser.GetOptions("bcr", string.Format("--{0}=myTier", optionName));
+            var options = _parser.GetOptions("bcr", $"--{optionName}=myTier");
             var bcrOptions = options as BcrOptions;
             
             Assert.That(bcrOptions.ValueOf(criteria).Single(), Is.EqualTo("myTier"));
@@ -64,7 +64,7 @@ namespace Unit4.Automation.Tests.Parser
         {
             var commandSeparatedTiers = new [] { "firstTier", "secondTier" };
             
-            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), string.Join(",", commandSeparatedTiers)));
+            var options = _parser.GetOptions("bcr", $"--{criteria.Name()}={string.Join(",", commandSeparatedTiers)}");
             var bcrOptions = options as BcrOptions;
 
             Assert.That(bcrOptions.ValueOf(criteria), Is.EquivalentTo(commandSeparatedTiers));
@@ -75,7 +75,7 @@ namespace Unit4.Automation.Tests.Parser
             [Values] Criteria criteria, 
             [Values("myTier,,,", ",myTier,,", ",,myTier,", ",,,myTier")] string option)
         {
-            var options = _parser.GetOptions("bcr", string.Format("--{0}={1}", criteria.Name(), option));
+            var options = _parser.GetOptions("bcr", $"--{criteria.Name()}={option}");
 
             var bcrOptions = options as BcrOptions;
 
@@ -87,7 +87,7 @@ namespace Unit4.Automation.Tests.Parser
         {
             var path = @"C:\my\path\to\output";
 
-            var options = _parser.GetOptions("bcr", string.Format("--output={0}", path));
+            var options = _parser.GetOptions("bcr", $"--output={path}");
             var bcrOptions = options as BcrOptions;
 
             Assert.That(bcrOptions.OutputDirectory, Is.EqualTo(path));

--- a/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
@@ -29,7 +29,7 @@ namespace Unit4.Automation.Tests.Parser
             Assert.That(_parser.GetOptions(command), Is.TypeOf(typeof(BcrOptions)));
         }
 
-        [TestCaseSource("CaseDifferences")]
+        [TestCaseSource(nameof(CaseDifferences))]
         public void GivenTheBcrCommand_ThenTheTierOptionShouldBeRecognised(Criteria criteria, string optionName)
         {
             var options = _parser.GetOptions("bcr", $"--{optionName}=myTier");

--- a/Unit4.Automation.Tests/Parser/CommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/CommandParserTests.cs
@@ -7,6 +7,7 @@ using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
 using Unit4.Automation.Tests.Helpers;
 using System.Collections.Generic;
 using System.Text;
+using Unit4.Automation.Commands;
 
 namespace Unit4.Automation.Tests.Parser
 {

--- a/Unit4.Automation.Tests/Parser/CommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/CommandParserTests.cs
@@ -1,12 +1,6 @@
-using System;
 using NUnit.Framework;
 using System.IO;
 using Unit4.Automation.Model;
-using System.Linq;
-using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
-using Unit4.Automation.Tests.Helpers;
-using System.Collections.Generic;
-using System.Text;
 using Unit4.Automation.Commands;
 
 namespace Unit4.Automation.Tests.Parser

--- a/Unit4.Automation.Tests/Parser/ConfigCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/ConfigCommandParserTests.cs
@@ -7,6 +7,7 @@ using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
 using Unit4.Automation.Tests.Helpers;
 using System.Collections.Generic;
 using System.Text;
+using Unit4.Automation.Commands;
 
 namespace Unit4.Automation.Tests.Parser
 {

--- a/Unit4.Automation.Tests/Parser/ConfigCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/ConfigCommandParserTests.cs
@@ -1,12 +1,6 @@
-using System;
 using NUnit.Framework;
 using System.IO;
 using Unit4.Automation.Model;
-using System.Linq;
-using Criteria = Unit4.Automation.Tests.Helpers.A.Criteria;
-using Unit4.Automation.Tests.Helpers;
-using System.Collections.Generic;
-using System.Text;
 using Unit4.Automation.Commands;
 
 namespace Unit4.Automation.Tests.Parser

--- a/Unit4.Automation.Tests/PathProviderTests.cs
+++ b/Unit4.Automation.Tests/PathProviderTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using Unit4.Automation;
 using Unit4.Automation.Model;
 using System.IO;
 

--- a/Unit4.Automation.Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4.Automation.Tests/ReportRunnerFactoryTests.cs
@@ -1,6 +1,7 @@
 using Unit4.Automation.Model;
 using NUnit.Framework;
 using Unit4.Automation.Commands.BcrCommand;
+using Unit4.Automation.Commands.ConfigCommand;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/ReportRunnerFactoryTests.cs
+++ b/Unit4.Automation.Tests/ReportRunnerFactoryTests.cs
@@ -1,5 +1,6 @@
 using Unit4.Automation.Model;
 using NUnit.Framework;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
+++ b/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
@@ -111,6 +111,7 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Unit4.Automation.Tests/Unit4WebConnectorTests.cs
+++ b/Unit4.Automation.Tests/Unit4WebConnectorTests.cs
@@ -4,7 +4,6 @@ using Unit4.Automation.Model;
 using ReportEngine.Base.Data.Provider;
 using ReportEngine.Base.Security;
 using Unit4.Automation.ReportEngine;
-using Moq;
 using System.Security;
 
 namespace Unit4.Automation.Tests

--- a/Unit4.Automation.Tests/Unit4WebConnectorTests.cs
+++ b/Unit4.Automation.Tests/Unit4WebConnectorTests.cs
@@ -19,7 +19,7 @@ namespace Unit4.Automation.Tests
             var config = new ConfigOptions(0, "foo");
             var connector = new Unit4WebConnector(manager, config).Create();
 
-            Assert.That(connector.Authenticator.Name, Is.EqualTo(manager.CredentialsOrDefault.Username));
+            Assert.That(connector.Authenticator.Name, Is.EqualTo(manager.Credentials.Username));
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace Unit4.Automation.Tests
             var connector = new Unit4WebConnector(manager, config).Create();
             var authenticator = connector.Authenticator as AgressoAuthenticator;
 
-            Assert.That(SecureStringHelper.ToString(authenticator.Password), Is.EqualTo(SecureStringHelper.ToString(manager.CredentialsOrDefault.Password)));
+            Assert.That(SecureStringHelper.ToString(authenticator.Password), Is.EqualTo(SecureStringHelper.ToString(manager.Credentials.Password)));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace Unit4.Automation.Tests
 
         private class FakeCredentialManager : ICredentialManager
         {
-            public ICredentials CredentialsOrDefault { get { return new FakeCredentials(); } }
+            public ICredentials Credentials { get { return new FakeCredentials(); } }
         }
 
         private class FakeCredentials : ICredentials

--- a/Unit4.Automation.Tests/Unit4WebConnectorTests.cs
+++ b/Unit4.Automation.Tests/Unit4WebConnectorTests.cs
@@ -55,13 +55,13 @@ namespace Unit4.Automation.Tests
 
         private class FakeCredentialManager : ICredentialManager
         {
-            public ICredentials Credentials { get { return new FakeCredentials(); } }
+            public ICredentials Credentials => new FakeCredentials();
         }
 
         private class FakeCredentials : ICredentials
         {
-            public string Username { get { return "username"; } }
-            public SecureString Password { get { return SecureStringHelper.ToSecureString("password"); } }
+            public string Username => "username";
+            public SecureString Password => SecureStringHelper.ToSecureString("password");
         }
     }
 }

--- a/Unit4.Automation.Tests/packages.config
+++ b/Unit4.Automation.Tests/packages.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Newtonsoft.Json" version="11.0.2" />
+    <package id="NUnit" version="3.10.1" />
+    <package id="NUnit.ConsoleRunner" version="3.8.0" />
+    <package id="Moq" version="4.8.2" />
+    <package id="System.Threading.Tasks.Extensions" version="4.3.0" />
+    <package id="System.ValueTuple" version="4.4.0" />
+    <package id="Castle.Core" version="4.2.1" />
+    <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" />
+</packages>

--- a/Unit4.DotSettings
+++ b/Unit4.DotSettings
@@ -1,0 +1,3 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
+</wpf:ResourceDictionary>

--- a/Unit4/Commands/BcrCommand/BcrFilter.cs
+++ b/Unit4/Commands/BcrCommand/BcrFilter.cs
@@ -3,7 +3,7 @@ using Unit4.Automation.Interfaces;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class BcrFilter : IBcrMiddleware
     {

--- a/Unit4/Commands/BcrCommand/BcrLineBuilder.cs
+++ b/Unit4/Commands/BcrCommand/BcrLineBuilder.cs
@@ -2,7 +2,7 @@ using System.Data;
 using System.Collections.Generic;
 using Unit4.Automation.Model;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class BcrLineBuilder
     {

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -3,7 +3,7 @@ using Unit4.Automation.Interfaces;
 using Unit4.Automation.ReportEngine;
 using Unit4.Automation.Model;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class BcrReader : IBcrReader
     {

--- a/Unit4/Commands/BcrCommand/BcrReport.cs
+++ b/Unit4/Commands/BcrCommand/BcrReport.cs
@@ -7,7 +7,7 @@ using System.Collections.Concurrent;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class BcrReport
     {

--- a/Unit4/Commands/BcrCommand/BcrReport.cs
+++ b/Unit4/Commands/BcrCommand/BcrReport.cs
@@ -25,7 +25,7 @@ namespace Unit4.Automation.Commands.BcrCommand
 
         public Bcr RunBcr(IEnumerable<IGrouping<string, CostCentre>> hierarchy)
         {
-            var reportsToRun = hierarchy.Select(x => new Report() { Tier = Tier.Tier3, Hierarchy = x });
+            var reportsToRun = hierarchy.Select(x => new Report(Tier.Tier3, x));
             
             return new Bcr(RunBcr(reportsToRun).ToList());
         }

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -71,7 +71,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         private class Progress : IDisposable
         {
             private readonly Stopwatch _stopwatch;
-            private long _elapsed = 0, _current = 0;
+            private long _elapsed, _current;
 
             private readonly TextWriter _output;
 

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Diagnostics;
 using Unit4.Automation.Interfaces;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class BcrReportRunner : IRunner
     {

--- a/Unit4/Commands/BcrCommand/Report.cs
+++ b/Unit4/Commands/BcrCommand/Report.cs
@@ -18,14 +18,13 @@ namespace Unit4.Automation.Commands.BcrCommand
         }
 
         public Tier Tier { get { return _tier; } }
-        public IGrouping<string, CostCentre> Hierarchy { get { return _hierarchy; } }
-        public string Parameter { get { return Hierarchy.Key; } }
+        public string Parameter { get { return _hierarchy.Key; } }
 
-        public bool ShouldFallBack { get { return (Tier == Tier.Tier3 || Tier == Tier.Tier4) && Hierarchy.Any(); } }
+        public bool ShouldFallBack { get { return (Tier == Tier.Tier3 || Tier == Tier.Tier4) && _hierarchy.Any(); } }
 
         public IEnumerable<Report> FallbackReports()
         {
-            var fallbackGroups = Hierarchy.GroupBy(FallBackGroupingFunction(Tier), x => x);
+            var fallbackGroups = _hierarchy.GroupBy(FallBackGroupingFunction(Tier), x => x);
 
             return fallbackGroups.Select(x => new Report(FallBackTier(Tier), x));
         }

--- a/Unit4/Commands/BcrCommand/Report.cs
+++ b/Unit4/Commands/BcrCommand/Report.cs
@@ -17,10 +17,11 @@ namespace Unit4.Automation.Commands.BcrCommand
             _hierarchy = hierarchy;    
         }
 
-        public Tier Tier { get { return _tier; } }
-        public string Parameter { get { return _hierarchy.Key; } }
+        public Tier Tier => _tier;
 
-        public bool ShouldFallBack { get { return (Tier == Tier.Tier3 || Tier == Tier.Tier4) && _hierarchy.Any(); } }
+        public string Parameter => _hierarchy.Key;
+
+        public bool ShouldFallBack => (Tier == Tier.Tier3 || Tier == Tier.Tier4) && _hierarchy.Any();
 
         public IEnumerable<Report> FallbackReports()
         {

--- a/Unit4/Commands/BcrCommand/Report.cs
+++ b/Unit4/Commands/BcrCommand/Report.cs
@@ -8,16 +8,15 @@ namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class Report
     {
-        private readonly Tier _tier;
         private readonly IGrouping<string, CostCentre> _hierarchy;
 
         public Report(Tier tier, IGrouping<string, CostCentre> hierarchy)
         {
-            _tier = tier;
+            Tier = tier;
             _hierarchy = hierarchy;    
         }
 
-        public Tier Tier => _tier;
+        public Tier Tier { get; }
 
         public string Parameter => _hierarchy.Key;
 

--- a/Unit4/Commands/BcrCommand/Report.cs
+++ b/Unit4/Commands/BcrCommand/Report.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using Tier = Unit4.Automation.BcrReport.Tier;
+using Tier = Unit4.Automation.Commands.BcrCommand.BcrReport.Tier;
 using Unit4.Automation.Model;
 
 namespace Unit4.Automation

--- a/Unit4/Commands/BcrCommand/Report.cs
+++ b/Unit4/Commands/BcrCommand/Report.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Tier = Unit4.Automation.Commands.BcrCommand.BcrReport.Tier;
 using Unit4.Automation.Model;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class Report
     {

--- a/Unit4/Commands/BcrCommand/Report.cs
+++ b/Unit4/Commands/BcrCommand/Report.cs
@@ -8,9 +8,17 @@ namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class Report
     {
-        public Tier Tier { get; set; }
-        public IGrouping<string, CostCentre> Hierarchy { get; set; }
+        private readonly Tier _tier;
+        private readonly IGrouping<string, CostCentre> _hierarchy;
 
+        public Report(Tier tier, IGrouping<string, CostCentre> hierarchy)
+        {
+            _tier = tier;
+            _hierarchy = hierarchy;    
+        }
+
+        public Tier Tier { get { return _tier; } }
+        public IGrouping<string, CostCentre> Hierarchy { get { return _hierarchy; } }
         public string Parameter { get { return Hierarchy.Key; } }
 
         public bool ShouldFallBack { get { return (Tier == Tier.Tier3 || Tier == Tier.Tier4) && Hierarchy.Any(); } }
@@ -19,7 +27,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         {
             var fallbackGroups = Hierarchy.GroupBy(FallBackGroupingFunction(Tier), x => x);
 
-            return fallbackGroups.Select(x => new Report() { Tier = FallBackTier(Tier), Hierarchy = x });
+            return fallbackGroups.Select(x => new Report(FallBackTier(Tier), x));
         }
 
         private Tier FallBackTier(Tier current)

--- a/Unit4/Commands/CommandParser.cs
+++ b/Unit4/Commands/CommandParser.cs
@@ -4,7 +4,7 @@ using CommandLine;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands
 {
     internal class CommandParser<TVerb, TVerb2>
         where TVerb : IOptions

--- a/Unit4/Commands/ConfigCommand/ConfigRunner.cs
+++ b/Unit4/Commands/ConfigCommand/ConfigRunner.cs
@@ -2,7 +2,7 @@ using System;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.ConfigCommand
 {
     internal class ConfigRunner : IRunner
     {

--- a/Unit4/Commands/ConfigCommand/ConfigRunner.cs
+++ b/Unit4/Commands/ConfigCommand/ConfigRunner.cs
@@ -1,4 +1,3 @@
-using System;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
 

--- a/Unit4/ConfigOptionsFile.cs
+++ b/Unit4/ConfigOptionsFile.cs
@@ -1,4 +1,3 @@
-using System;
 using Unit4.Automation.Model;
 using Unit4.Automation.Interfaces;
 

--- a/Unit4/ConfigOptionsFile.cs
+++ b/Unit4/ConfigOptionsFile.cs
@@ -12,10 +12,7 @@ namespace Unit4.Automation
             _file = new JsonFile<ConfigOptions>(path);
         }
 
-        public void Save(ConfigOptions options)
-        {
-            _file.Write(options);
-        }
+        public void Save(ConfigOptions options) => _file.Write(options);
 
         public ConfigOptions Load()
         {
@@ -27,9 +24,6 @@ namespace Unit4.Automation
             throw new System.IO.FileNotFoundException("Could not load config from file");
         }
 
-        public bool Exists()
-        {
-            return _file.Exists();
-        }
+        public bool Exists() => _file.Exists();
     }
 }

--- a/Unit4/Excel.cs
+++ b/Unit4/Excel.cs
@@ -46,12 +46,12 @@ namespace Unit4.Automation
 
         private void AddSubtotals(MSExcel.Worksheet sheet, int totalRow, int startRow, int endRow)
         {
-            ((MSExcel.Range)sheet.Cells[totalRow, 13]).FormulaR1C1 = string.Format("=SUBTOTAL(109, R{0}C:R{1}C", startRow, endRow);
-            ((MSExcel.Range)sheet.Cells[totalRow, 14]).FormulaR1C1 = string.Format("=SUBTOTAL(109, R{0}C:R{1}C", startRow, endRow);
-            ((MSExcel.Range)sheet.Cells[totalRow, 15]).FormulaR1C1 = string.Format("=SUBTOTAL(109, R{0}C:R{1}C", startRow, endRow);
-            ((MSExcel.Range)sheet.Cells[totalRow, 16]).FormulaR1C1 = string.Format("=SUBTOTAL(109, R{0}C:R{1}C", startRow, endRow);
-            ((MSExcel.Range)sheet.Cells[totalRow, 17]).FormulaR1C1 = string.Format("=SUBTOTAL(109, R{0}C:R{1}C", startRow, endRow);
-            ((MSExcel.Range)sheet.Cells[totalRow, 18]).FormulaR1C1 = string.Format("=SUBTOTAL(109, R{0}C:R{1}C", startRow, endRow);
+            ((MSExcel.Range)sheet.Cells[totalRow, 13]).FormulaR1C1 = $"=SUBTOTAL(109, R{startRow}C:R{endRow}C";
+            ((MSExcel.Range)sheet.Cells[totalRow, 14]).FormulaR1C1 = $"=SUBTOTAL(109, R{startRow}C:R{endRow}C";
+            ((MSExcel.Range)sheet.Cells[totalRow, 15]).FormulaR1C1 = $"=SUBTOTAL(109, R{startRow}C:R{endRow}C";
+            ((MSExcel.Range)sheet.Cells[totalRow, 16]).FormulaR1C1 = $"=SUBTOTAL(109, R{startRow}C:R{endRow}C";
+            ((MSExcel.Range)sheet.Cells[totalRow, 17]).FormulaR1C1 = $"=SUBTOTAL(109, R{startRow}C:R{endRow}C";
+            ((MSExcel.Range)sheet.Cells[totalRow, 18]).FormulaR1C1 = $"=SUBTOTAL(109, R{startRow}C:R{endRow}C";
 
             SetNumberFormat(sheet.Range[sheet.Cells[totalRow, 13], sheet.Cells[totalRow, 18]]);
         }

--- a/Unit4/Excel.cs
+++ b/Unit4/Excel.cs
@@ -24,15 +24,15 @@ namespace Unit4.Automation
 
             var data = bcr.Lines.ToList();
 
-            Parallel.For(0, data.Count(), new ParallelOptions { MaxDegreeOfParallelism = 3 }, i =>
+            Parallel.For(0, data.Count, new ParallelOptions { MaxDegreeOfParallelism = 3 }, i =>
             {
                 var rowNumber = i + rowToStartData;
                 AddRow(sheet, rowNumber, data.ElementAt(i));
             });
 
-            SetNumberFormat(sheet.Range[sheet.Cells[rowToStartData, 13], sheet.Cells[rowToStartData + data.Count() - 1, 18]]);
+            SetNumberFormat(sheet.Range[sheet.Cells[rowToStartData, 13], sheet.Cells[rowToStartData + data.Count - 1, 18]]);
 
-            var lastRow = rowToStartData + data.Count() - 1;
+            var lastRow = rowToStartData + data.Count - 1;
             AutoFilter(sheet.Range[sheet.Cells[headerRow, 1], sheet.Cells[lastRow, 18]]);
 
             AddSubtotals(sheet, 1, rowToStartData, lastRow);

--- a/Unit4/Interfaces/ICredentialManager.cs
+++ b/Unit4/Interfaces/ICredentialManager.cs
@@ -1,5 +1,3 @@
-using Unit4.Automation.Model;
-
 namespace Unit4.Automation.Interfaces
 {
     internal interface ICredentialManager

--- a/Unit4/Interfaces/ICredentialManager.cs
+++ b/Unit4/Interfaces/ICredentialManager.cs
@@ -4,6 +4,6 @@ namespace Unit4.Automation.Interfaces
 {
     internal interface ICredentialManager
     {
-        ICredentials CredentialsOrDefault { get; }
+        ICredentials Credentials { get; }
     }
 }

--- a/Unit4/JsonFile.cs
+++ b/Unit4/JsonFile.cs
@@ -23,14 +23,8 @@ namespace Unit4.Automation
             return JsonConvert.DeserializeObject<T>(File.ReadAllText(_path));
         }
 
-        public bool Exists()
-        {
-            return File.Exists(_path);
-        }
+        public bool Exists() => File.Exists(_path);
 
-        public bool IsDirty()
-        {
-            return false;
-        }
+        public bool IsDirty() => false;
     }
 }

--- a/Unit4/Model/Bcr.cs
+++ b/Unit4/Model/Bcr.cs
@@ -19,12 +19,6 @@ namespace Unit4.Automation.Model
             }
         }
 
-        public IEnumerable<BcrLine> Lines
-        {
-            get
-            {
-                return _lines;
-            }
-        }
+        public IEnumerable<BcrLine> Lines => _lines;
     }
 }

--- a/Unit4/Model/Bcr.cs
+++ b/Unit4/Model/Bcr.cs
@@ -5,20 +5,18 @@ namespace Unit4.Automation.Model
 {
     internal class Bcr
     {
-        private readonly IEnumerable<BcrLine> _lines;
-
         public Bcr(IEnumerable<BcrLine> lines)
         {
             if (lines == null)
             {
-                _lines = Enumerable.Empty<BcrLine>();
+                Lines = Enumerable.Empty<BcrLine>();
             }
             else
             {
-                _lines = lines;
+                Lines = lines;
             }
         }
 
-        public IEnumerable<BcrLine> Lines => _lines;
+        public IEnumerable<BcrLine> Lines { get; }
     }
 }

--- a/Unit4/Model/Bcr.cs
+++ b/Unit4/Model/Bcr.cs
@@ -7,14 +7,7 @@ namespace Unit4.Automation.Model
     {
         public Bcr(IEnumerable<BcrLine> lines)
         {
-            if (lines == null)
-            {
-                Lines = Enumerable.Empty<BcrLine>();
-            }
-            else
-            {
-                Lines = lines;
-            }
+            Lines = lines ?? Enumerable.Empty<BcrLine>();
         }
 
         public IEnumerable<BcrLine> Lines { get; }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -13,7 +13,6 @@ namespace Unit4.Automation.Model
         private readonly IEnumerable<string> _tier3;
         private readonly IEnumerable<string> _tier4;
         private readonly IEnumerable<string> _costCentre;
-        private readonly string _outputDirectory;
 
         public BcrOptions() : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), null)
         {}
@@ -28,7 +27,7 @@ namespace Unit4.Automation.Model
             _tier3 = tier3;
             _tier4 = tier4;
             _costCentre = costCentre;
-            _outputDirectory = outputDirectory;
+            OutputDirectory = outputDirectory;
         }
 
         [Option(HelpText = "Filter by a tier 1 code.", Separator=',')]
@@ -47,7 +46,7 @@ namespace Unit4.Automation.Model
         public IEnumerable<string> CostCentre => PreventNullAndRemoveEmptyStrings(_costCentre);
 
         [Option("output", HelpText = "The directory to save the bcr in. The directory must already exist.")]
-        public string OutputDirectory => _outputDirectory;
+        public string OutputDirectory { get; }
 
         private IEnumerable<string> PreventNullAndRemoveEmptyStrings(IEnumerable<string> enumerable)
         {

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -32,58 +32,22 @@ namespace Unit4.Automation.Model
         }
 
         [Option(HelpText = "Filter by a tier 1 code.", Separator=',')]
-        public IEnumerable<string> Tier1
-        {
-            get
-            {
-                return PreventNullAndRemoveEmptyStrings(_tier1);
-            }
-        }
+        public IEnumerable<string> Tier1 => PreventNullAndRemoveEmptyStrings(_tier1);
 
         [Option(HelpText = "Filter by a tier 2 code.", Separator=',')]
-        public IEnumerable<string> Tier2
-        {
-            get
-            {
-                return PreventNullAndRemoveEmptyStrings(_tier2);
-            }
-        }
+        public IEnumerable<string> Tier2 => PreventNullAndRemoveEmptyStrings(_tier2);
 
         [Option(HelpText = "Filter by a tier 3 code.", Separator=',')]
-        public IEnumerable<string> Tier3
-        {
-            get
-            {
-                return PreventNullAndRemoveEmptyStrings(_tier3);
-            }
-        }
+        public IEnumerable<string> Tier3 => PreventNullAndRemoveEmptyStrings(_tier3);
 
         [Option(HelpText = "Filter by a tier 4 code.", Separator=',')]
-        public IEnumerable<string> Tier4
-        {
-            get
-            {
-                return PreventNullAndRemoveEmptyStrings(_tier4);
-            }
-        }
+        public IEnumerable<string> Tier4 => PreventNullAndRemoveEmptyStrings(_tier4);
 
         [Option(HelpText = "Filter by a cost centre.", Separator=',')]
-        public IEnumerable<string> CostCentre
-        {
-            get
-            {
-                return PreventNullAndRemoveEmptyStrings(_costCentre);
-            }
-        }
+        public IEnumerable<string> CostCentre => PreventNullAndRemoveEmptyStrings(_costCentre);
 
         [Option("output", HelpText = "The directory to save the bcr in. The directory must already exist.")]
-        public string OutputDirectory
-        {
-            get
-            {
-                return _outputDirectory;
-            }
-        }
+        public string OutputDirectory => _outputDirectory;
 
         private IEnumerable<string> PreventNullAndRemoveEmptyStrings(IEnumerable<string> enumerable)
         {

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -7,17 +7,16 @@ namespace Unit4.Automation.Model
     [Verb("config", HelpText = "Configure the Unit4 connection details.")]
     internal class ConfigOptions : IOptions
     {
-        private readonly int _client;
         private readonly string _url;
 
         public ConfigOptions(int client = 0, string url = null)
         {
-            _client = client;
+            Client = client;
             _url = url;
         }
 
         [Option(HelpText = "Set the Unit4 client.")]
-        public int Client => _client;
+        public int Client { get; }
 
         [Option(HelpText = "Set the Unit4 SOAP service URL.")]
         public string Url

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -62,7 +62,7 @@ namespace Unit4.Automation.Model
 
         public override string ToString()
         {
-            return string.Format("Client = {0}; Url = {1}", Client, Url);
+            return $"Client = {Client}; Url = {Url}";
         }
     }
 }

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -17,13 +17,7 @@ namespace Unit4.Automation.Model
         }
 
         [Option(HelpText = "Set the Unit4 client.")]
-        public int Client
-        {
-            get
-            {
-                return _client;
-            }
-        }
+        public int Client => _client;
 
         [Option(HelpText = "Set the Unit4 SOAP service URL.")]
         public string Url
@@ -60,9 +54,6 @@ namespace Unit4.Automation.Model
             }
         }
 
-        public override string ToString()
-        {
-            return $"Client = {Client}; Url = {Url}";
-        }
+        public override string ToString() => $"Client = {Client}; Url = {Url}";
     }
 }

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using Unit4.Automation.Interfaces;
 using CommandLine;
-using System.IO;
 using System;
 
 namespace Unit4.Automation.Model

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -39,7 +39,7 @@ namespace Unit4.Automation.Model
                 return false;
             }
 
-            return otherConfig.Client == this.Client && string.Equals(otherConfig.Url, this.Url);
+            return otherConfig.Client == Client && string.Equals(otherConfig.Url, Url);
         }
 
         public override int GetHashCode()

--- a/Unit4/Model/Credentials.cs
+++ b/Unit4/Model/Credentials.cs
@@ -14,20 +14,8 @@ namespace Unit4.Automation.Model
             _password = password ?? new SecureString();
         }
 
-        public string Username
-        { 
-            get 
-            { 
-                return _username; 
-            }
-        }
+        public string Username => _username; 
 
-        public SecureString Password
-        {
-            get
-            {
-                return _password;
-            }
-        }
+        public SecureString Password => _password;
     }
 }

--- a/Unit4/Model/Credentials.cs
+++ b/Unit4/Model/Credentials.cs
@@ -5,17 +5,14 @@ namespace Unit4.Automation.Model
 {
     internal class Credentials : ICredentials
     {
-        private readonly string _username;
-        private readonly SecureString _password;
-
         public Credentials(string username = "", SecureString password = null)
         {
-            _username = username;
-            _password = password ?? new SecureString();
+            Username = username;
+            Password = password ?? new SecureString();
         }
 
-        public string Username => _username; 
+        public string Username { get; } 
 
-        public SecureString Password => _password;
+        public SecureString Password { get; }
     }
 }

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Unit4.Automation.Model;
+using Unit4.Automation.Commands;
 
 namespace Unit4.Automation
 {

--- a/Unit4/ReportEngine/Logging.cs
+++ b/Unit4/ReportEngine/Logging.cs
@@ -12,7 +12,7 @@ namespace Unit4.Automation.ReportEngine
     {
         private readonly string _logFilePath;
 
-        public string Path { get { return _logFilePath; } }
+        public string Path => _logFilePath;
 
         public Logging()
         {

--- a/Unit4/ReportEngine/Logging.cs
+++ b/Unit4/ReportEngine/Logging.cs
@@ -33,9 +33,10 @@ namespace Unit4.Automation.ReportEngine
 
         public void Error(Exception exception)
         {
-            if (exception is LineException)
+            var lineException = exception as LineException;
+            if (lineException != null)
             {
-                Log.Error(((LineException)exception).FullLine);
+                Log.Error(lineException.FullLine);
             }
 
             Log.Error(exception.Message);

--- a/Unit4/ReportEngine/Logging.cs
+++ b/Unit4/ReportEngine/Logging.cs
@@ -25,20 +25,11 @@ namespace Unit4.Automation.ReportEngine
             Log.Open(logFile);
         }
 
-        public void Close()
-        {
-            Log.Close();
-        }
+        public void Close() => Log.Close();
 
-        public void Info(string message)
-        {
-            Log.Info(message);
-        }
+        public void Info(string message) => Log.Info(message);
 
-        public void Error(string message)
-        {
-            Log.Error(message);
-        }
+        public void Error(string message) => Log.Error(message);
 
         public void Error(Exception exception)
         {

--- a/Unit4/ReportEngine/Unit4Engine.cs
+++ b/Unit4/ReportEngine/Unit4Engine.cs
@@ -20,8 +20,7 @@ namespace Unit4.Automation.ReportEngine
         {
             using (var webProvider = new Unit4WebProvider(_config).Create())
             {
-                var engine = new Engine(webProvider, ClientType.External);
-                engine.InProcess = true;
+                var engine = new Engine(webProvider, ClientType.External) { InProcess = true };
 
                 using (engine)
                 {

--- a/Unit4/ReportEngine/Unit4WebConnector.cs
+++ b/Unit4/ReportEngine/Unit4WebConnector.cs
@@ -18,7 +18,7 @@ namespace Unit4.Automation.ReportEngine
         
         public WebProviderConnector Create()
         {
-            var credentials = _manager.CredentialsOrDefault;
+            var credentials = _manager.Credentials;
 
             var agressoAuthenticator = new AgressoAuthenticator();
             agressoAuthenticator.Password = credentials.Password;

--- a/Unit4/ReportEngine/Unit4WebConnector.cs
+++ b/Unit4/ReportEngine/Unit4WebConnector.cs
@@ -1,4 +1,3 @@
-using ReportEngine.Base.Security;
 using ReportEngine.Base.Data.Provider;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;

--- a/Unit4/ReportEngine/Unit4WebConnector.cs
+++ b/Unit4/ReportEngine/Unit4WebConnector.cs
@@ -19,8 +19,7 @@ namespace Unit4.Automation.ReportEngine
         {
             var credentials = _manager.Credentials;
 
-            var agressoAuthenticator = new AgressoAuthenticator();
-            agressoAuthenticator.Password = credentials.Password;
+            var agressoAuthenticator = new AgressoAuthenticator() { Password = credentials.Password };
             
             var authenticators = new BaseAuthenticator[1]
             {

--- a/Unit4/ReportEngine/Unit4WebConnector.cs
+++ b/Unit4/ReportEngine/Unit4WebConnector.cs
@@ -20,11 +20,8 @@ namespace Unit4.Automation.ReportEngine
             var credentials = _manager.Credentials;
 
             var agressoAuthenticator = new AgressoAuthenticator() { Password = credentials.Password };
-            
-            var authenticators = new BaseAuthenticator[1]
-            {
-                agressoAuthenticator
-            };
+            var authenticators = new BaseAuthenticator[] { agressoAuthenticator };
+
             var connector = new WebProviderConnector() 
             { 
                 Name = "WebService",

--- a/Unit4/ReportEngine/Unit4WebProvider.cs
+++ b/Unit4/ReportEngine/Unit4WebProvider.cs
@@ -14,14 +14,8 @@ namespace Unit4.Automation.ReportEngine
             _provider = new WebProvider(connector);
         }
 
-        public WebProvider Create()
-        {
-            return _provider;
-        }
+        public WebProvider Create() => _provider;
 
-        public void Dispose()
-        {
-            _provider.Dispose();
-        }
+        public void Dispose() => _provider.Dispose();
     }
 }

--- a/Unit4/ReportEngine/Unit4WebProvider.cs
+++ b/Unit4/ReportEngine/Unit4WebProvider.cs
@@ -1,8 +1,6 @@
 using System;
 using ReportEngine.Provider.WebService;
-using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
-using Unit4.Automation;
 
 namespace Unit4.Automation.ReportEngine
 {

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -2,6 +2,7 @@ using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
 using Unit4.Automation.ReportEngine;
 using System.IO;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation
 {

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -8,30 +8,40 @@ namespace Unit4.Automation
 {
     internal class ReportRunnerFactory
     {
-        public IRunner Create(IOptions options)
+        private readonly ConfigOptionsFile _file;
+
+        public ReportRunnerFactory()
         {
             var configPath = Path.Combine(Directory.GetCurrentDirectory(), "config.json");
-            var file = new ConfigOptionsFile(configPath);
-            
+            _file = new ConfigOptionsFile(configPath);
+        }
+
+        public IRunner Create(IOptions options)
+        { 
             var bcrOptions = options as BcrOptions;
             if (bcrOptions != null)
             {
-                var log = new Logging();
-                var config = file.Exists() ? file.Load() : new ConfigOptions();
-                var reader = new BcrReader(log, config);
-                var filter = new BcrFilter(bcrOptions);
-                var writer = new Excel();
-                var pathProvider = new PathProvider(bcrOptions);
-                return new BcrReportRunner(log, reader, filter, writer, pathProvider);
+                return CreateBcrRunner(bcrOptions);
             }
 
             var configOptions = options as ConfigOptions;
             if (configOptions != null)
             {
-                return new ConfigRunner(configOptions, file);
+                return new ConfigRunner(configOptions, _file);
             }
 
             return new NullRunner();
+        }
+
+        private IRunner CreateBcrRunner(BcrOptions bcrOptions)
+        {
+            var log = new Logging();
+            var config = _file.Exists() ? _file.Load() : new ConfigOptions();
+            var reader = new BcrReader(log, config);
+            var filter = new BcrFilter(bcrOptions);
+            var writer = new Excel();
+            var pathProvider = new PathProvider(bcrOptions);
+            return new BcrReportRunner(log, reader, filter, writer, pathProvider);
         }
     }
 }

--- a/Unit4/ReportRunnerFactory.cs
+++ b/Unit4/ReportRunnerFactory.cs
@@ -3,6 +3,7 @@ using Unit4.Automation.Model;
 using Unit4.Automation.ReportEngine;
 using System.IO;
 using Unit4.Automation.Commands.BcrCommand;
+using Unit4.Automation.Commands.ConfigCommand;
 
 namespace Unit4.Automation
 {

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -125,6 +125,7 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -74,7 +74,6 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Model\BcrLine.cs" />
-    <Compile Include="BcrLineBuilder.cs" />
     <Compile Include="ReportEngine\Logging.cs" />
     <Compile Include="CostCentresProvider.cs" />
     <Compile Include="CostCentreHierarchy.cs" />
@@ -92,13 +91,14 @@
     <Compile Include="NullRunner.cs" />
     <Compile Include="ConfigRunner.cs" />
     <Compile Include="ConfigOptionsFile.cs" />
-    <Compile Include="BcrReportRunner.cs" />
-    <Compile Include="BcrReader.cs" />
-    <Compile Include="BcrFilter.cs" />
+    <Compile Include="Commands\BcrCommand\BcrLineBuilder.cs" />
+    <Compile Include="Commands\BcrCommand\BcrFilter.cs" />
+    <Compile Include="Commands\BcrCommand\BcrReader.cs" />
+    <Compile Include="Commands\BcrCommand\BcrReport.cs" />
+    <Compile Include="Commands\BcrCommand\BcrReportRunner.cs" />
+    <Compile Include="Commands\BcrCommand\Report.cs" />
     <Compile Include="ReportRunnerFactory.cs" />
-    <Compile Include="BcrReport.cs" />
     <Compile Include="Cache.cs" />
-    <Compile Include="Report.cs" />
     <Compile Include="JsonFile.cs" />
     <Compile Include="Excel.cs" />
     <Compile Include="Resql.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -89,7 +89,7 @@
     <Compile Include="ReportEngine\Unit4WebProvider.cs" />
     <Compile Include="ReportEngine\Unit4WebConnector.cs" />
     <Compile Include="NullRunner.cs" />
-    <Compile Include="ConfigRunner.cs" />
+    <Compile Include="Commands\ConfigCommand\ConfigRunner.cs" />
     <Compile Include="ConfigOptionsFile.cs" />
     <Compile Include="Commands\BcrCommand\BcrLineBuilder.cs" />
     <Compile Include="Commands\BcrCommand\BcrFilter.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -102,7 +102,7 @@
     <Compile Include="JsonFile.cs" />
     <Compile Include="Excel.cs" />
     <Compile Include="Resql.cs" />
-    <Compile Include="CommandParser.cs" />
+    <Compile Include="Commands\CommandParser.cs" />
     <Compile Include="PathProvider.cs" />
     <Compile Include="WindowsCredentialManager.cs" />
     <Compile Include="Interfaces\ICredentials.cs" />

--- a/Unit4/WindowsCredentialManager.cs
+++ b/Unit4/WindowsCredentialManager.cs
@@ -9,7 +9,7 @@ namespace Unit4.Automation
     {
         private const string _credentialName = "Unit4 Automation";
 
-        public ICredentials CredentialsOrDefault
+        public ICredentials Credentials
         {
             get
             {

--- a/Unit4/WindowsCredentialManager.cs
+++ b/Unit4/WindowsCredentialManager.cs
@@ -28,7 +28,7 @@ namespace Unit4.Automation
         private class MissingCredentialsException : Exception
         {
             public MissingCredentialsException()
-                : this(string.Format("The {0} credential does not exist in Credential Manager. Please create it.", _credentialName))
+                : this($"The {_credentialName} credential does not exist in Credential Manager. Please create it.")
             {
             }
 

--- a/Unit4/packages.config
+++ b/Unit4/packages.config
@@ -11,4 +11,5 @@
     <package id="CommandLineParser" version="2.2.1" />
     <package id="WiX" version="3.11.1" />
     <package id="CredentialManagement" version="1.0.2" />
+    <package id="Microsoft.Net.Compilers" version="1.3.2" />
 </packages>

--- a/Unit4/packages.config
+++ b/Unit4/packages.config
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Newtonsoft.Json" version="11.0.2" />
-    <package id="NUnit" version="3.10.1" />
-    <package id="NUnit.ConsoleRunner" version="3.8.0" />
-    <package id="Moq" version="4.8.2" />
-    <package id="System.Threading.Tasks.Extensions" version="4.3.0" />
-    <package id="System.ValueTuple" version="4.4.0" />
-    <package id="Castle.Core" version="4.2.1" />
     <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" />
     <package id="CommandLineParser" version="2.2.1" />
     <package id="WiX" version="3.11.1" />

--- a/build-tools.psm1
+++ b/build-tools.psm1
@@ -30,6 +30,11 @@ function Uninstall {
     msiexec.exe /x unit4-automation.msi /passive
 }
 
+function Inspect {
+    inspectcode.exe -f=Html --output=InspectCodeReport.Html .\Unit4.sln
+    .\InspectCodeReport.html
+}
+
 export-modulemember -function Restore
 export-modulemember -function Build
 export-modulemember -function Test
@@ -38,3 +43,4 @@ export-modulemember -function Help
 export-modulemember -function Installer
 export-modulemember -function Install
 export-modulemember -function Uninstall
+export-modulemember -function Inspect

--- a/build-tools.psm1
+++ b/build-tools.psm1
@@ -31,7 +31,7 @@ function Uninstall {
 }
 
 function Inspect {
-    inspectcode.exe -f=Html --output=InspectCodeReport.Html .\Unit4.sln
+    inspectcode.exe -f=Html --output=InspectCodeReport.html --profile=Unit4.DotSettings .\Unit4.sln
     .\InspectCodeReport.html
 }
 


### PR DESCRIPTION
This moves to C# 6, using `Microsoft.Net.Compilers`.

Generally tidies up namespaces, uses C# 6 features, other small refactorings.