### PR TITLE
Only fetch tier3s needed from SOAP service

### DIFF
--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -17,8 +17,9 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenNoCache_ThenItShouldFetchAllTier3Hierarchies()
         {
+            var lines = new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "tier3") };
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "tier3" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(lines.AsDataSet());
             var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, Mock.Of<IFile<Bcr>>(), engine.Object);
 
             reader.Read();
@@ -43,8 +44,9 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenTier3WithOneCostCentresCached_ThenItShouldOnlyFetchTheUncachedTier3()
         {
+            var lines = new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "b").With(A.Criteria.CostCentre, "b") };
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "b", Code = "b" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(lines.AsDataSet());
 
             var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "a").With(A.Criteria.CostCentre, "a"));
 
@@ -61,8 +63,12 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenCachedCostCentreInOneTier3AndUncachedCostCentreInSameTier3_ThenItShouldFetchTheTier3()
         {
+            var lines = new BcrLine[] { 
+                A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"), 
+                A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "b")
+            };
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(lines.AsDataSet());
 
             var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"));
 

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -47,14 +47,14 @@ namespace Unit4.Automation.Tests
         public void GivenTier3WithOneCostCentresCached_ThenItShouldOnlyFetchTheUncachedTier3()
         {
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(CreateDataSet(new CostCentre() { Tier3 = "b" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(CreateDataSet(new CostCentre() { Tier3 = "b", Code = "b" }));
 
             var bcrCache = new Mock<IFile<Bcr>>();
             bcrCache.Setup(x => x.Exists()).Returns(true);
             bcrCache.Setup(x => x.IsDirty()).Returns(false);
-            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "a").Build() }));
+            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "a").With(A.Criteria.CostCentre, "a").Build() }));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a" }, new CostCentre() { Tier3 = "b" } }, new BcrOptions(), bcrCache.Object, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a", Code = "a" }, new CostCentre() { Tier3 = "b", Code = "b" } }, new BcrOptions(), bcrCache.Object, engine.Object);
 
             var tier3sInBcr = reader.Read().Lines.Select(x => x.CostCentre.Tier3);
 

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -65,13 +65,13 @@ namespace Unit4.Automation.Tests
         public void GivenCachedCostCentreInOneTier3AndUncachedCostCentreInSameTier3_ThenItShouldFetchTheTier3()
         {
             var lines = new BcrLine[] { 
-                A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"), 
+                A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a").Actuals(100), 
                 A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "b")
             };
             var engine = new Mock<IUnit4Engine>();
             engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(lines.AsDataSet());
 
-            var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"));
+            var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a").Actuals(50));
 
             var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" } }, cache, engine.Object);
 

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Unit4.Automation.Commands.BcrCommand;
 using System.Collections.Generic;
+using Unit4.Automation.Tests.Helpers;
 
 namespace Unit4.Automation.Tests
 {
@@ -23,6 +24,21 @@ namespace Unit4.Automation.Tests
             engine.Verify(x => x.RunReport(Resql.BcrTier3("tier3")), Times.Once);
         }
 
+        [Test]
+        public void GivenTier3WithAllCostCentresCached_ThenItShouldNotFetchThatTier3()
+        {
+            var engine = new Mock<IUnit4Engine>();
+            var bcrCache = new Mock<IFile<Bcr>>();
+            bcrCache.Setup(x => x.Exists()).Returns(true);
+            bcrCache.Setup(x => x.IsDirty()).Returns(false);
+            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "tier3") }));
+
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), bcrCache.Object, engine.Object);
+
+            reader.Read();
+
+            engine.Verify(x => x.RunReport(Resql.BcrTier3("tier3")), Times.Never);
+        }
 
         private BcrReader CreateReader(IEnumerable<CostCentre> allCostCentres, BcrOptions options, IFile<Bcr> bcrCache, IUnit4Engine engine)
         {

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Unit4.Automation.Commands.BcrCommand;
 using System.Collections.Generic;
 using Unit4.Automation.Tests.Helpers;
+using System.Data;
 
 namespace Unit4.Automation.Tests
 {
@@ -17,6 +18,7 @@ namespace Unit4.Automation.Tests
         public void GivenNoCache_ThenItShouldFetchAllTier3Hierarchies()
         {
             var engine = new Mock<IUnit4Engine>();
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(CreateDataSet("tier3"));
             var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), Mock.Of<IFile<Bcr>>(), engine.Object);
 
             reader.Read();
@@ -28,10 +30,11 @@ namespace Unit4.Automation.Tests
         public void GivenTier3WithAllCostCentresCached_ThenItShouldNotFetchThatTier3()
         {
             var engine = new Mock<IUnit4Engine>();
+
             var bcrCache = new Mock<IFile<Bcr>>();
             bcrCache.Setup(x => x.Exists()).Returns(true);
             bcrCache.Setup(x => x.IsDirty()).Returns(false);
-            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "tier3") }));
+            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "tier3").Build() }));
 
             var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), bcrCache.Object, engine.Object);
 
@@ -44,17 +47,21 @@ namespace Unit4.Automation.Tests
         public void GivenTier3WithOneCostCentresCached_ThenItShouldOnlyFetchTheUncachedTier3()
         {
             var engine = new Mock<IUnit4Engine>();
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(CreateDataSet("b"));
+
             var bcrCache = new Mock<IFile<Bcr>>();
             bcrCache.Setup(x => x.Exists()).Returns(true);
             bcrCache.Setup(x => x.IsDirty()).Returns(false);
-            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "a") }));
+            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "a").Build() }));
 
             var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a" }, new CostCentre() { Tier3 = "b" } }, new BcrOptions(), bcrCache.Object, engine.Object);
 
-            reader.Read();
+            var tier3sInBcr = reader.Read().Lines.Select(x => x.CostCentre.Tier3);
 
             engine.Verify(x => x.RunReport(Resql.BcrTier3("b")), Times.Once);
             engine.Verify(x => x.RunReport(Resql.BcrTier3("a")), Times.Never);
+
+            Assert.That(tier3sInBcr, Is.EquivalentTo(new [] { "a", "b" }));
         }
 
         private BcrReader CreateReader(IEnumerable<CostCentre> allCostCentres, BcrOptions options, IFile<Bcr> bcrCache, IUnit4Engine engine)
@@ -74,6 +81,34 @@ namespace Unit4.Automation.Tests
                 Mock.Of<IFile<SerializableCostCentreList>>(),
                 factory.Object,
                 costCentresProvider.Object);
+        }
+
+        private DataSet CreateDataSet(string tier3)
+        {
+            var dataset = new DataSet();
+            var table = dataset.Tables.Add("foo");
+            table.Columns.Add("r0r0r0r3dim2", typeof(string));
+            table.Columns.Add("r0r0r3dim2", typeof(string));
+            table.Columns.Add("r0r3dim2", typeof(string));
+            table.Columns.Add("r3dim2", typeof(string));
+            table.Columns.Add("dim2", typeof(string));
+            table.Columns.Add("xr0r0r0r3dim2", typeof(string));
+            table.Columns.Add("xr0r0r3dim2", typeof(string));
+            table.Columns.Add("xr0r3dim2", typeof(string));
+            table.Columns.Add("xr3dim2", typeof(string));
+            table.Columns.Add("xdim2", typeof(string));
+            table.Columns.Add("dim1", typeof(string));
+            table.Columns.Add("xdim1", typeof(string));
+            table.Columns.Add("plb_amount", typeof(double));
+            table.Columns.Add("f0_budget_to_da13", typeof(double));
+            table.Columns.Add("f1_total_exp_to16", typeof(double));
+            table.Columns.Add("f3_variance_to_15", typeof(double));
+            table.Columns.Add("plf_amount", typeof(double));
+            table.Columns.Add("f2_outturn_vari18", typeof(double));
+
+            var row = table.NewRow();
+            table.Rows.Add(string.Empty, string.Empty, tier3, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0, 0, 0, 0, 0, 0);
+            return dataset;
         }
     }
 }

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -18,7 +18,7 @@ namespace Unit4.Automation.Tests
         public void GivenNoCache_ThenItShouldFetchAllTier3Hierarchies()
         {
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(CreateDataSet(new CostCentre() { Tier3 = "tier3" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "tier3" }));
             var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), Mock.Of<IFile<Bcr>>(), engine.Object);
 
             reader.Read();
@@ -47,7 +47,7 @@ namespace Unit4.Automation.Tests
         public void GivenTier3WithOneCostCentresCached_ThenItShouldOnlyFetchTheUncachedTier3()
         {
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(CreateDataSet(new CostCentre() { Tier3 = "b", Code = "b" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "b", Code = "b" }));
 
             var bcrCache = new Mock<IFile<Bcr>>();
             bcrCache.Setup(x => x.Exists()).Returns(true);
@@ -68,7 +68,7 @@ namespace Unit4.Automation.Tests
         public void GivenCachedCostCentreInOneTier3AndUncachedCostCentreInSameTier3_ThenItShouldFetchTheTier3()
         {
             var engine = new Mock<IUnit4Engine>();
-            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(CreateDataSet(new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" }));
+            engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" }));
 
             var bcrCache = new Mock<IFile<Bcr>>();
             bcrCache.Setup(x => x.Exists()).Returns(true);
@@ -101,37 +101,6 @@ namespace Unit4.Automation.Tests
                 Mock.Of<IFile<SerializableCostCentreList>>(),
                 factory.Object,
                 costCentresProvider.Object);
-        }
-
-        private DataSet CreateDataSet(params CostCentre[] costCentres)
-        {
-            var dataset = new DataSet();
-            var table = dataset.Tables.Add("foo");
-            table.Columns.Add("r0r0r0r3dim2", typeof(string));
-            table.Columns.Add("r0r0r3dim2", typeof(string));
-            table.Columns.Add("r0r3dim2", typeof(string));
-            table.Columns.Add("r3dim2", typeof(string));
-            table.Columns.Add("dim2", typeof(string));
-            table.Columns.Add("xr0r0r0r3dim2", typeof(string));
-            table.Columns.Add("xr0r0r3dim2", typeof(string));
-            table.Columns.Add("xr0r3dim2", typeof(string));
-            table.Columns.Add("xr3dim2", typeof(string));
-            table.Columns.Add("xdim2", typeof(string));
-            table.Columns.Add("dim1", typeof(string));
-            table.Columns.Add("xdim1", typeof(string));
-            table.Columns.Add("plb_amount", typeof(double));
-            table.Columns.Add("f0_budget_to_da13", typeof(double));
-            table.Columns.Add("f1_total_exp_to16", typeof(double));
-            table.Columns.Add("f3_variance_to_15", typeof(double));
-            table.Columns.Add("plf_amount", typeof(double));
-            table.Columns.Add("f2_outturn_vari18", typeof(double));
-
-            foreach (var code in costCentres)
-            {
-                var row = table.NewRow();
-                table.Rows.Add(string.Empty, string.Empty, code.Tier3, string.Empty, code.Code, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0, 0, 0, 0, 0, 0);
-            }
-            return dataset;
         }
     }
 }

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -31,12 +31,9 @@ namespace Unit4.Automation.Tests
         {
             var engine = new Mock<IUnit4Engine>();
 
-            var bcrCache = new Mock<IFile<Bcr>>();
-            bcrCache.Setup(x => x.Exists()).Returns(true);
-            bcrCache.Setup(x => x.IsDirty()).Returns(false);
-            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "tier3").Build() }));
+            var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3"));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), bcrCache.Object, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), cache, engine.Object);
 
             reader.Read();
 
@@ -49,12 +46,9 @@ namespace Unit4.Automation.Tests
             var engine = new Mock<IUnit4Engine>();
             engine.Setup(x => x.RunReport(Resql.BcrTier3("b"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "b", Code = "b" }));
 
-            var bcrCache = new Mock<IFile<Bcr>>();
-            bcrCache.Setup(x => x.Exists()).Returns(true);
-            bcrCache.Setup(x => x.IsDirty()).Returns(false);
-            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "a").With(A.Criteria.CostCentre, "a").Build() }));
+            var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "a").With(A.Criteria.CostCentre, "a"));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a", Code = "a" }, new CostCentre() { Tier3 = "b", Code = "b" } }, new BcrOptions(), bcrCache.Object, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a", Code = "a" }, new CostCentre() { Tier3 = "b", Code = "b" } }, new BcrOptions(), cache, engine.Object);
 
             var tier3sInBcr = reader.Read().Lines.Select(x => x.CostCentre.Tier3);
 
@@ -70,18 +64,24 @@ namespace Unit4.Automation.Tests
             var engine = new Mock<IUnit4Engine>();
             engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" }));
 
-            var bcrCache = new Mock<IFile<Bcr>>();
-            bcrCache.Setup(x => x.Exists()).Returns(true);
-            bcrCache.Setup(x => x.IsDirty()).Returns(false);
-            bcrCache.Setup(x => x.Read()).Returns(new Bcr(new BcrLine[] { A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a").Build() }));
+            var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" } }, new BcrOptions(), bcrCache.Object, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" } }, new BcrOptions(), cache, engine.Object);
 
             var costCentresInBcr = reader.Read().Lines.Select(x => x.CostCentre.Code);
 
             engine.Verify(x => x.RunReport(Resql.BcrTier3("tier3")), Times.Once);
 
             Assert.That(costCentresInBcr, Is.EquivalentTo(new [] { "a", "b" }));
+        }
+
+        private IFile<Bcr> CreateCache(params BcrLine[] lines)
+        {
+            var cache = new Mock<IFile<Bcr>>();
+            cache.Setup(x => x.Exists()).Returns(true);
+            cache.Setup(x => x.IsDirty()).Returns(false);
+            cache.Setup(x => x.Read()).Returns(new Bcr(lines));
+            return cache.Object;
         }
 
         private BcrReader CreateReader(IEnumerable<CostCentre> allCostCentres, BcrOptions options, IFile<Bcr> bcrCache, IUnit4Engine engine)

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -2,12 +2,10 @@ using Unit4.Automation.Model;
 using Unit4.Automation.Interfaces;
 using NUnit.Framework;
 using Moq;
-using System.IO;
 using System.Linq;
 using Unit4.Automation.Commands.BcrCommand;
 using System.Collections.Generic;
 using Unit4.Automation.Tests.Helpers;
-using System.Data;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -123,7 +123,6 @@ namespace Unit4.Automation.Tests
             return new BcrReader(
                 Mock.Of<ILogging>(),
                 new BcrOptions(),
-                new ProgramConfig(() => 0, () => string.Empty),
                 bcrCache,
                 Mock.Of<IFile<SerializableCostCentreList>>(),
                 factory.Object,

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -83,7 +83,7 @@ namespace Unit4.Automation.Tests
         }
 
         [Test]
-        public void GivenCachedAndFetchedLines_ThenTheOldCacheAndNewLinesShouldBeWrittenToCache()
+        public void GivenTheFinalBcr_ThenItShouldBeWrittenToTheCache()
         {
             var lines = new BcrLine[] { 
                 A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"), 

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using System.IO;
 using System.Linq;
 using Unit4.Automation.Commands.BcrCommand;
+using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests
 {
@@ -15,27 +16,31 @@ namespace Unit4.Automation.Tests
         public void GivenNoCache_ThenItShouldFetchAllTier3Hierarchies()
         {
             var engine = new Mock<IUnit4Engine>();
-
-            var factory = new Mock<IUnit4EngineFactory>();
-            factory.Setup(x => x.Create()).Returns(engine.Object);
-
-            var costCentresProvider = new Mock<ICostCentresProvider>();
-            var costCentres = new SerializableCostCentreList() { CostCentres = new [] { new CostCentre() { Tier3 = "tier3" } } };
-            costCentresProvider.Setup(x => x.GetCostCentres()).Returns(costCentres);
-
-            var reader = 
-                new BcrReader(
-                    Mock.Of<ILogging>(),
-                    new BcrOptions(),
-                    new ProgramConfig(() => 0, () => string.Empty),
-                    Mock.Of<IFile<Bcr>>(),
-                    Mock.Of<IFile<SerializableCostCentreList>>(),
-                    factory.Object,
-                    costCentresProvider.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), Mock.Of<IFile<Bcr>>(), engine.Object);
 
             reader.Read();
 
             engine.Verify(x => x.RunReport(Resql.BcrTier3("tier3")), Times.Once);
+        }
+
+
+        private BcrReader CreateReader(IEnumerable<CostCentre> allCostCentres, BcrOptions options, IFile<Bcr> bcrCache, IUnit4Engine engine)
+        {
+            var factory = new Mock<IUnit4EngineFactory>();
+            factory.Setup(x => x.Create()).Returns(engine);
+
+            var costCentresProvider = new Mock<ICostCentresProvider>();
+            var costCentres = new SerializableCostCentreList() { CostCentres = allCostCentres };
+            costCentresProvider.Setup(x => x.GetCostCentres()).Returns(costCentres);
+
+            return new BcrReader(
+                Mock.Of<ILogging>(),
+                options,
+                new ProgramConfig(() => 0, () => string.Empty),
+                bcrCache,
+                Mock.Of<IFile<SerializableCostCentreList>>(),
+                factory.Object,
+                costCentresProvider.Object);
         }
     }
 }

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -19,7 +19,7 @@ namespace Unit4.Automation.Tests
         {
             var engine = new Mock<IUnit4Engine>();
             engine.Setup(x => x.RunReport(Resql.BcrTier3("tier3"))).Returns(BcrDataSetBuilder.Build(new CostCentre() { Tier3 = "tier3" }));
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), Mock.Of<IFile<Bcr>>(), engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, Mock.Of<IFile<Bcr>>(), engine.Object);
 
             reader.Read();
 
@@ -33,7 +33,7 @@ namespace Unit4.Automation.Tests
 
             var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3"));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, new BcrOptions(), cache, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3" } }, cache, engine.Object);
 
             reader.Read();
 
@@ -48,7 +48,7 @@ namespace Unit4.Automation.Tests
 
             var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "a").With(A.Criteria.CostCentre, "a"));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a", Code = "a" }, new CostCentre() { Tier3 = "b", Code = "b" } }, new BcrOptions(), cache, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "a", Code = "a" }, new CostCentre() { Tier3 = "b", Code = "b" } }, cache, engine.Object);
 
             var tier3sInBcr = reader.Read().Lines.Select(x => x.CostCentre.Tier3);
 
@@ -66,7 +66,7 @@ namespace Unit4.Automation.Tests
 
             var cache = CreateCache(A.BcrLine().With(A.Criteria.Tier3, "tier3").With(A.Criteria.CostCentre, "a"));
 
-            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" } }, new BcrOptions(), cache, engine.Object);
+            var reader = CreateReader(new [] { new CostCentre() { Tier3 = "tier3", Code = "a" }, new CostCentre() { Tier3 = "tier3", Code = "b" } }, cache, engine.Object);
 
             var costCentresInBcr = reader.Read().Lines.Select(x => x.CostCentre.Code);
 
@@ -84,7 +84,7 @@ namespace Unit4.Automation.Tests
             return cache.Object;
         }
 
-        private BcrReader CreateReader(IEnumerable<CostCentre> allCostCentres, BcrOptions options, IFile<Bcr> bcrCache, IUnit4Engine engine)
+        private BcrReader CreateReader(IEnumerable<CostCentre> allCostCentres, IFile<Bcr> bcrCache, IUnit4Engine engine)
         {
             var factory = new Mock<IUnit4EngineFactory>();
             factory.Setup(x => x.Create()).Returns(engine);
@@ -95,7 +95,7 @@ namespace Unit4.Automation.Tests
 
             return new BcrReader(
                 Mock.Of<ILogging>(),
-                options,
+                new BcrOptions(),
                 new ProgramConfig(() => 0, () => string.Empty),
                 bcrCache,
                 Mock.Of<IFile<SerializableCostCentreList>>(),

--- a/Unit4.Automation.Tests/BcrReaderTests.cs
+++ b/Unit4.Automation.Tests/BcrReaderTests.cs
@@ -1,0 +1,41 @@
+using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
+using NUnit.Framework;
+using Moq;
+using System.IO;
+using System.Linq;
+using Unit4.Automation.Commands.BcrCommand;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    internal class BcrReaderTests
+    {
+        [Test]
+        public void GivenNoCache_ThenItShouldFetchAllTier3Hierarchies()
+        {
+            var engine = new Mock<IUnit4Engine>();
+
+            var factory = new Mock<IUnit4EngineFactory>();
+            factory.Setup(x => x.Create()).Returns(engine.Object);
+
+            var costCentresProvider = new Mock<ICostCentresProvider>();
+            var costCentres = new SerializableCostCentreList() { CostCentres = new [] { new CostCentre() { Tier3 = "tier3" } } };
+            costCentresProvider.Setup(x => x.GetCostCentres()).Returns(costCentres);
+
+            var reader = 
+                new BcrReader(
+                    Mock.Of<ILogging>(),
+                    new BcrOptions(),
+                    new ProgramConfig(() => 0, () => string.Empty),
+                    Mock.Of<IFile<Bcr>>(),
+                    Mock.Of<IFile<SerializableCostCentreList>>(),
+                    factory.Object,
+                    costCentresProvider.Object);
+
+            reader.Read();
+
+            engine.Verify(x => x.RunReport(Resql.BcrTier3("tier3")), Times.Once);
+        }
+    }
+}

--- a/Unit4.Automation.Tests/CostCentreHierarchyTests.cs
+++ b/Unit4.Automation.Tests/CostCentreHierarchyTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation.Tests
 {

--- a/Unit4.Automation.Tests/CostCentreHierarchyTests.cs
+++ b/Unit4.Automation.Tests/CostCentreHierarchyTests.cs
@@ -11,7 +11,7 @@ namespace Unit4.Automation.Tests
         [Test]
         public void GivenNoCostCentres_ThenThereShouldBeNoGroups()
         {
-            var hierarchy = new CostCentreHierarchy(new DummyCostCentres());
+            var hierarchy = new CostCentreHierarchy(new DummyCostCentres(), new BcrOptions());
             
             var tier3Hierarchy = hierarchy.GetHierarchyByTier3();
 
@@ -26,7 +26,7 @@ namespace Unit4.Automation.Tests
                                     new CostCentre() { Tier3 = "A", Tier4 = "B" },
                                     new CostCentre() { Tier3 = "A", Tier4 = "C" },
                                     new CostCentre() { Tier3 = "A", Tier4 = "D" }
-                                ));
+                                ), new BcrOptions());
             
             var tier3Hierarchy = hierarchy.GetHierarchyByTier3();
 
@@ -40,7 +40,7 @@ namespace Unit4.Automation.Tests
                                 new DummyCostCentres(
                                     new CostCentre() { Tier3 = "A", Tier4 = "B" },
                                     new CostCentre() { Tier3 = "C", Tier4 = "D" }
-                                ));
+                                ), new BcrOptions());
             
             var tier3Hierarchy = hierarchy.GetHierarchyByTier3();
 
@@ -55,7 +55,7 @@ namespace Unit4.Automation.Tests
                 new CostCentre() { Tier3 = "A", Tier4 = "C" },
                 new CostCentre() { Tier3 = "A", Tier4 = "D" }
             };
-            var hierarchy = new CostCentreHierarchy(new DummyCostCentres(costCentres));
+            var hierarchy = new CostCentreHierarchy(new DummyCostCentres(costCentres), new BcrOptions());
             
             var actualCostCentres = hierarchy.GetHierarchyByTier3().Single().ToList();
 

--- a/Unit4.Automation.Tests/CostCentreHierarchyTests.cs
+++ b/Unit4.Automation.Tests/CostCentreHierarchyTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System.Linq;
+using System.Collections.Generic;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
 
@@ -60,6 +61,33 @@ namespace Unit4.Automation.Tests
             var actualCostCentres = hierarchy.GetHierarchyByTier3().Single().ToList();
 
             Assert.That(actualCostCentres, Is.EquivalentTo(costCentres));
+        }
+
+        [Test, TestCaseSource(nameof(FilteredCostCentreOptions))]
+        public void GivenCostCentreOption_ThenOnlyTheTier3ForThatCostCentreShouldBeIncluded(BcrOptions options)
+        {
+            var costCentres = new [] {
+                new CostCentre() { Tier1 = "A1", Tier2 = "A2", Tier3 = "A3", Tier4 = "A4", Code = "A5" },
+                new CostCentre() { Tier1 = "B1", Tier2 = "B2", Tier3 = "B3", Tier4 = "B4", Code = "B5" }
+            };
+
+            var hierarchy = new CostCentreHierarchy(new DummyCostCentres(costCentres), options);
+
+            var filteredList = hierarchy.GetHierarchyByTier3();
+
+            Assert.That(filteredList.Select(x => x.Key), Is.EquivalentTo(new [] { "A3" }));
+        }
+
+        private static IEnumerable<BcrOptions> FilteredCostCentreOptions
+        {
+            get
+            {
+                yield return new BcrOptions(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), new [] { "A5" }, null);
+                yield return new BcrOptions(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), new [] { "A4" }, Enumerable.Empty<string>(), null);
+                yield return new BcrOptions(Enumerable.Empty<string>(), Enumerable.Empty<string>(), new [] { "A3" }, Enumerable.Empty<string>(), Enumerable.Empty<string>(), null);
+                yield return new BcrOptions(Enumerable.Empty<string>(), new [] { "A2" }, Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), null);
+                yield return new BcrOptions(new [] { "A1" }, Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), null);
+            }
         }
 
         private class DummyCostCentres : ICache<SerializableCostCentreList>

--- a/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Data;
 using Unit4.Automation.Model;
-using System.Linq;
 using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests.Helpers

--- a/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
@@ -2,17 +2,13 @@ using System;
 using System.Data;
 using Unit4.Automation.Model;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests.Helpers
 {
-    internal class BcrDataSetBuilder
+    internal static class BcrDataSetBuilder
     {
-        public static DataSet Build(params CostCentre[] costCentres)
-        {
-            return Build(costCentres.Select(x => new BcrLine() { CostCentre = x }).ToArray());
-        }
-
-        private static DataSet Build(params BcrLine[] lines)
+        public static DataSet AsDataSet(this IEnumerable<BcrLine> lines)
         {
             var dataset = new DataSet();
             var table = dataset.Tables.Add("foo");

--- a/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Data;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Tests.Helpers
+{
+    internal class BcrDataSetBuilder
+    {
+        public static DataSet Build(params CostCentre[] costCentres)
+        {
+            var dataset = new DataSet();
+            var table = dataset.Tables.Add("foo");
+            table.Columns.Add("r0r0r0r3dim2", typeof(string));
+            table.Columns.Add("r0r0r3dim2", typeof(string));
+            table.Columns.Add("r0r3dim2", typeof(string));
+            table.Columns.Add("r3dim2", typeof(string));
+            table.Columns.Add("dim2", typeof(string));
+            table.Columns.Add("xr0r0r0r3dim2", typeof(string));
+            table.Columns.Add("xr0r0r3dim2", typeof(string));
+            table.Columns.Add("xr0r3dim2", typeof(string));
+            table.Columns.Add("xr3dim2", typeof(string));
+            table.Columns.Add("xdim2", typeof(string));
+            table.Columns.Add("dim1", typeof(string));
+            table.Columns.Add("xdim1", typeof(string));
+            table.Columns.Add("plb_amount", typeof(double));
+            table.Columns.Add("f0_budget_to_da13", typeof(double));
+            table.Columns.Add("f1_total_exp_to16", typeof(double));
+            table.Columns.Add("f3_variance_to_15", typeof(double));
+            table.Columns.Add("plf_amount", typeof(double));
+            table.Columns.Add("f2_outturn_vari18", typeof(double));
+
+            foreach (var code in costCentres)
+            {
+                var row = table.NewRow();
+                table.Rows.Add(code.Tier1, code.Tier2, code.Tier3, code.Tier3, code.Code, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0, 0, 0, 0, 0, 0);
+            }
+            return dataset;
+        }
+    }
+}

--- a/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
@@ -35,7 +35,7 @@ namespace Unit4.Automation.Tests.Helpers
             {
                 var row = table.NewRow();
                 var code = line.CostCentre;
-                table.Rows.Add(code.Tier1, code.Tier2, code.Tier3, code.Tier3, code.Code, code.Tier1Name, code.Tier2Name, code.Tier3Name, code.Tier4Name, code.CostCentreName, line.Account, line.AccountName, line.Budget, line.Profile, line.Actuals, line.Variance, line.Forecast, line.OutturnVariance);
+                table.Rows.Add(code.Tier1, code.Tier2, code.Tier3, code.Tier4, code.Code, code.Tier1Name, code.Tier2Name, code.Tier3Name, code.Tier4Name, code.CostCentreName, line.Account, line.AccountName, line.Budget, line.Profile, line.Actuals, line.Variance, line.Forecast, line.OutturnVariance);
             }
             return dataset;
         }

--- a/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrDataSetBuilder.cs
@@ -1,12 +1,18 @@
 using System;
 using System.Data;
 using Unit4.Automation.Model;
+using System.Linq;
 
 namespace Unit4.Automation.Tests.Helpers
 {
     internal class BcrDataSetBuilder
     {
         public static DataSet Build(params CostCentre[] costCentres)
+        {
+            return Build(costCentres.Select(x => new BcrLine() { CostCentre = x }).ToArray());
+        }
+
+        private static DataSet Build(params BcrLine[] lines)
         {
             var dataset = new DataSet();
             var table = dataset.Tables.Add("foo");
@@ -29,10 +35,11 @@ namespace Unit4.Automation.Tests.Helpers
             table.Columns.Add("plf_amount", typeof(double));
             table.Columns.Add("f2_outturn_vari18", typeof(double));
 
-            foreach (var code in costCentres)
+            foreach (var line in lines)
             {
                 var row = table.NewRow();
-                table.Rows.Add(code.Tier1, code.Tier2, code.Tier3, code.Tier3, code.Code, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0, 0, 0, 0, 0, 0);
+                var code = line.CostCentre;
+                table.Rows.Add(code.Tier1, code.Tier2, code.Tier3, code.Tier3, code.Code, code.Tier1Name, code.Tier2Name, code.Tier3Name, code.Tier4Name, code.CostCentreName, line.Account, line.AccountName, line.Budget, line.Profile, line.Actuals, line.Variance, line.Forecast, line.OutturnVariance);
             }
             return dataset;
         }

--- a/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
@@ -11,6 +11,8 @@ namespace Unit4.Automation.Tests.Helpers
         private string _tier3;
         private string _tier4;
         private string _costCentre;
+
+        private double _actuals;
         
         public BcrLineBuilder With(Criteria criteria, string value)
         {
@@ -24,6 +26,12 @@ namespace Unit4.Automation.Tests.Helpers
                 default: throw new NotSupportedException(criteria.ToString());
             }
 
+            return this;
+        }
+
+        public BcrLineBuilder Actuals(double actuals)
+        {
+            _actuals = actuals;
             return this;
         }
 
@@ -43,7 +51,7 @@ namespace Unit4.Automation.Tests.Helpers
                 AccountName = null,
                 Budget = 0,
                 Profile = 0,
-                Actuals = 0,
+                Actuals = builder._actuals,
                 Variance = 0,
                 Forecast = 0,
                 OutturnVariance = 0

--- a/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
@@ -38,7 +38,15 @@ namespace Unit4.Automation.Tests.Helpers
                     Tier3 = builder._tier3,
                     Tier4 = builder._tier4,
                     Code = builder._costCentre,
-                }
+                },
+                Account = null,
+                AccountName = null,
+                Budget = 0,
+                Profile = 0,
+                Actuals = 0,
+                Variance = 0,
+                Forecast = 0,
+                OutturnVariance = 0
             };
         }
     }

--- a/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
+++ b/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Helpers\BcrFilterBuilder.cs" />
     <Compile Include="Helpers\IEnumerablePowersetExtension.cs" />
     <Compile Include="Helpers\TempFile.cs" />
+    <Compile Include="Helpers\BcrDataSetBuilder.cs" />
     <Compile Include="Unit4WebConnectorTests.cs" />
     <Compile Include="ExcelTests.cs" />
     <Compile Include="CostCentreHierarchyTests.cs" />

--- a/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
+++ b/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ExcelTests.cs" />
     <Compile Include="CostCentreHierarchyTests.cs" />
     <Compile Include="BcrReportTests.cs" />
+    <Compile Include="BcrReaderTests.cs" />
     <Compile Include="ConfigRunnerTests.cs" />
     <Compile Include="ResqlTests.cs" />
     <Compile Include="Parser\BcrCommandParserTests.cs" />

--- a/Unit4/Commands/BcrCommand/BcrFilter.cs
+++ b/Unit4/Commands/BcrCommand/BcrFilter.cs
@@ -21,27 +21,7 @@ namespace Unit4.Automation.Commands.BcrCommand
 
         private bool Matches(CostCentre costCentre)
         {
-            if (!HasOption(_options.Tier1) && !HasOption(_options.Tier2) && !HasOption(_options.Tier3) && !HasOption(_options.Tier4) && !HasOption(_options.CostCentre))
-            {
-                return true;
-            }
-
-            var matchesTier1 = HasOption(_options.Tier1) && Matches(_options.Tier1, costCentre.Tier1);
-            var matchesTier2 = HasOption(_options.Tier2) && Matches(_options.Tier2, costCentre.Tier2);
-            var matchesTier3 = HasOption(_options.Tier3) && Matches(_options.Tier3, costCentre.Tier3);
-            var matchesTier4 = HasOption(_options.Tier4) && Matches(_options.Tier4, costCentre.Tier4);
-            var matchesCostCentre = HasOption(_options.CostCentre) && Matches(_options.CostCentre, costCentre.Code);
-            return matchesTier1 || matchesTier2 || matchesTier3 || matchesTier4 || matchesCostCentre;
-        }
-
-        private bool HasOption(IEnumerable<string> option)
-        {
-            return option != null && option.Any();
-        }
-
-        private bool Matches(IEnumerable<string> options, string value)
-        {
-            return options.Any(x => string.Equals(x, value));
+            return costCentre.Matches(_options);
         }
     }
 }

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -21,7 +21,7 @@ namespace Unit4.Automation.Commands.BcrCommand
 
             var costCentreList = 
                 new Cache<SerializableCostCentreList>(
-                        () => new CostCentresProvider(config).GetCostCentres(), 
+                        () => new CostCentresProvider(config, factory).GetCostCentres(), 
                         costCentreFile);
             _hierarchy = new CostCentreHierarchy(costCentreList, options);
             _config = config;

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -47,9 +47,10 @@ namespace Unit4.Automation.Commands.BcrCommand
 
             var fetchedCostCentres = fetchedLines.Select(x => x.CostCentre.Code).Distinct();
             var cachedLinesNotUpdated = cachedLines.Where(x => !fetchedCostCentres.Contains(x.CostCentre.Code));
-            var allLines = fetchedLines.Union(cachedLinesNotUpdated);
 
-            return new Bcr(allLines);
+            var bcr = new Bcr(fetchedLines.Union(cachedLinesNotUpdated));
+            _bcrFile.Write(bcr);
+            return bcr;
         }
 
         private IEnumerable<BcrLine> GetCachedLines()

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -13,7 +13,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         private readonly IFile<Bcr> _bcrFile;
         private readonly IUnit4EngineFactory _factory;
 
-        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile, IUnit4EngineFactory factory)
+        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile, IUnit4EngineFactory factory, ICostCentresProvider provider)
         {
             _log = log;
             _bcrFile = bcrFile;
@@ -21,7 +21,7 @@ namespace Unit4.Automation.Commands.BcrCommand
 
             var costCentreList = 
                 new Cache<SerializableCostCentreList>(
-                        () => new CostCentresProvider(config, factory).GetCostCentres(), 
+                        () => provider.GetCostCentres(), 
                         costCentreFile);
             _hierarchy = new CostCentreHierarchy(costCentreList, options);
             _config = config;

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -27,11 +27,12 @@ namespace Unit4.Automation.Commands.BcrCommand
         {
             var tier3Hierarchy = _hierarchy.GetHierarchyByTier3();
 
+            var file = new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json"));
             var factory = new Unit4EngineFactory(_config);
             var bcrReport = 
                 new Cache<Bcr>(
                     () => new BcrReport(factory, _log).RunBcr(tier3Hierarchy), 
-                    new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")));
+                    file);
 
             return bcrReport.Fetch();
         }

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -43,7 +43,11 @@ namespace Unit4.Automation.Commands.BcrCommand
                 return new Bcr(cachedLines);
             }
 
-            return new BcrReport(_factory, _log).RunBcr(hierarchyToFetch);
+            var fetchedLines = new BcrReport(_factory, _log).RunBcr(hierarchyToFetch).Lines;
+
+            var allLines = fetchedLines.Union(cachedLines);
+
+            return new Bcr(allLines);
         }
 
         private IEnumerable<BcrLine> GetCachedLines()

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -9,11 +9,10 @@ namespace Unit4.Automation.Commands.BcrCommand
     {
         private readonly ILogging _log;
         private readonly CostCentreHierarchy _hierarchy;
-        private readonly ProgramConfig _config;
         private readonly IFile<Bcr> _bcrFile;
         private readonly IUnit4EngineFactory _factory;
 
-        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile, IUnit4EngineFactory factory, ICostCentresProvider provider)
+        public BcrReader(ILogging log, BcrOptions options, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile, IUnit4EngineFactory factory, ICostCentresProvider provider)
         {
             _log = log;
             _bcrFile = bcrFile;
@@ -24,7 +23,6 @@ namespace Unit4.Automation.Commands.BcrCommand
                         () => provider.GetCostCentres(), 
                         costCentreFile);
             _hierarchy = new CostCentreHierarchy(costCentreList, options);
-            _config = config;
         }
 
         public Bcr Read()

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -11,11 +11,13 @@ namespace Unit4.Automation.Commands.BcrCommand
         private readonly CostCentreHierarchy _hierarchy;
         private readonly ProgramConfig _config;
         private readonly IFile<Bcr> _bcrFile;
+        private readonly IUnit4EngineFactory _factory;
 
-        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile)
+        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile, IUnit4EngineFactory factory)
         {
             _log = log;
             _bcrFile = bcrFile;
+            _factory = factory;
 
             var costCentreList = 
                 new Cache<SerializableCostCentreList>(
@@ -29,10 +31,9 @@ namespace Unit4.Automation.Commands.BcrCommand
         {
             var tier3Hierarchy = _hierarchy.GetHierarchyByTier3();
 
-            var factory = new Unit4EngineFactory(_config);
             var bcrReport = 
                 new Cache<Bcr>(
-                    () => new BcrReport(factory, _log).RunBcr(tier3Hierarchy), 
+                    () => new BcrReport(_factory, _log).RunBcr(tier3Hierarchy), 
                     _bcrFile);
 
             return bcrReport.Fetch();

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -1,6 +1,4 @@
-using System.IO;
 using Unit4.Automation.Interfaces;
-using Unit4.Automation.ReportEngine;
 using Unit4.Automation.Model;
 using System.Collections.Generic;
 using System.Linq;

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -34,9 +34,9 @@ namespace Unit4.Automation.Commands.BcrCommand
             var tier3Hierarchy = _hierarchy.GetHierarchyByTier3();
 
             var cachedLines = GetCachedLines();
-            var cachedTier3s = cachedLines.Select(x => x.CostCentre.Tier3).Distinct();
+            var cachedCostCentres = cachedLines.Select(x => x.CostCentre.Code).Distinct();
 
-            var hierarchyToFetch = tier3Hierarchy.Where(x => !cachedTier3s.Contains(x.Key));
+            var hierarchyToFetch = tier3Hierarchy.Where(x => x.Any(y => !cachedCostCentres.Contains(y.Code)));
 
             if (!hierarchyToFetch.Any())
             {
@@ -45,7 +45,9 @@ namespace Unit4.Automation.Commands.BcrCommand
 
             var fetchedLines = new BcrReport(_factory, _log).RunBcr(hierarchyToFetch).Lines;
 
-            var allLines = fetchedLines.Union(cachedLines);
+            var fetchedCostCentres = fetchedLines.Select(x => x.CostCentre.Code).Distinct();
+            var cachedLinesNotUpdated = cachedLines.Where(x => !fetchedCostCentres.Contains(x.CostCentre.Code));
+            var allLines = fetchedLines.Union(cachedLinesNotUpdated);
 
             return new Bcr(allLines);
         }

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -11,7 +11,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         private readonly CostCentreHierarchy _hierarchy;
         private readonly ProgramConfig _config;
 
-        public BcrReader(ILogging log, ProgramConfig config)
+        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config)
         {
             _log = log;
 
@@ -19,7 +19,7 @@ namespace Unit4.Automation.Commands.BcrCommand
                 new Cache<SerializableCostCentreList>(
                         () => new CostCentresProvider(config).GetCostCentres(), 
                         new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")));
-            _hierarchy = new CostCentreHierarchy(costCentreList);
+            _hierarchy = new CostCentreHierarchy(costCentreList, options);
             _config = config;
         }
 

--- a/Unit4/Commands/BcrCommand/BcrReader.cs
+++ b/Unit4/Commands/BcrCommand/BcrReader.cs
@@ -12,12 +12,10 @@ namespace Unit4.Automation.Commands.BcrCommand
         private readonly ProgramConfig _config;
         private readonly IFile<Bcr> _bcrFile;
 
-        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile)
+        public BcrReader(ILogging log, BcrOptions options, ProgramConfig config, IFile<Bcr> bcrFile, IFile<SerializableCostCentreList> costCentreFile)
         {
             _log = log;
             _bcrFile = bcrFile;
-
-            var costCentreFile = new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json"));
 
             var costCentreList = 
                 new Cache<SerializableCostCentreList>(

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -73,7 +73,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         public static BcrReportRunner Create(BcrOptions options, ProgramConfig config)
         { 
             var log = new Logging();
-            var reader = new BcrReader(log, options, config);
+            var reader = new BcrReader(log, options, config, new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")));
             var filter = new BcrFilter(options);
             var writer = new Excel();
             var pathProvider = new PathProvider(options);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -71,7 +71,8 @@ namespace Unit4.Automation.Commands.BcrCommand
         }
 
         public static BcrReportRunner Create(BcrOptions options, ProgramConfig config)
-        { 
+        {
+            var assemblyDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             var log = new Logging();
             var factory = new Unit4EngineFactory(config);
             var reader = 
@@ -79,8 +80,8 @@ namespace Unit4.Automation.Commands.BcrCommand
                     log, 
                     options, 
                     config, 
-                    new JsonFile<Bcr>(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "cache", "bcr.json")),
-                    new JsonFile<SerializableCostCentreList>(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "cache", "costCentres.json")),
+                    new JsonFile<Bcr>(Path.Combine(assemblyDirectory, "cache", "bcr.json")),
+                    new JsonFile<SerializableCostCentreList>(Path.Combine(assemblyDirectory, "cache", "costCentres.json")),
                     factory,
                     new CostCentresProvider(config, factory));
             var filter = new BcrFilter(options);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -79,7 +79,8 @@ namespace Unit4.Automation.Commands.BcrCommand
                     options, 
                     config, 
                     new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")),
-                    new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")));
+                    new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")),
+                    new Unit4EngineFactory(config));
             var filter = new BcrFilter(options);
             var writer = new Excel();
             var pathProvider = new PathProvider(options);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -79,8 +79,8 @@ namespace Unit4.Automation.Commands.BcrCommand
                     log, 
                     options, 
                     config, 
-                    new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")),
-                    new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")),
+                    new JsonFile<Bcr>(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "cache", "bcr.json")),
+                    new JsonFile<SerializableCostCentreList>(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "cache", "costCentres.json")),
                     factory,
                     new CostCentresProvider(config, factory));
             var filter = new BcrFilter(options);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -73,7 +73,13 @@ namespace Unit4.Automation.Commands.BcrCommand
         public static BcrReportRunner Create(BcrOptions options, ProgramConfig config)
         { 
             var log = new Logging();
-            var reader = new BcrReader(log, options, config, new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")));
+            var reader = 
+                new BcrReader(
+                    log, 
+                    options, 
+                    config, 
+                    new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")),
+                    new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")));
             var filter = new BcrFilter(options);
             var writer = new Excel();
             var pathProvider = new PathProvider(options);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -79,7 +79,6 @@ namespace Unit4.Automation.Commands.BcrCommand
                 new BcrReader(
                     log, 
                     options, 
-                    config, 
                     new JsonFile<Bcr>(Path.Combine(assemblyDirectory, "cache", "bcr.json")),
                     new JsonFile<SerializableCostCentreList>(Path.Combine(assemblyDirectory, "cache", "costCentres.json")),
                     factory,

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -70,13 +70,13 @@ namespace Unit4.Automation.Commands.BcrCommand
             }
         }
 
-        public static BcrReportRunner Create(BcrOptions bcrOptions, ProgramConfig config)
+        public static BcrReportRunner Create(BcrOptions options, ProgramConfig config)
         { 
             var log = new Logging();
-            var reader = new BcrReader(log, bcrOptions, config);
-            var filter = new BcrFilter(bcrOptions);
+            var reader = new BcrReader(log, options, config);
+            var filter = new BcrFilter(options);
             var writer = new Excel();
-            var pathProvider = new PathProvider(bcrOptions);
+            var pathProvider = new PathProvider(options);
             return new BcrReportRunner(log, reader, filter, writer, pathProvider);
         }
 

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -73,6 +73,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         public static BcrReportRunner Create(BcrOptions options, ProgramConfig config)
         { 
             var log = new Logging();
+            var factory = new Unit4EngineFactory(config);
             var reader = 
                 new BcrReader(
                     log, 
@@ -80,7 +81,8 @@ namespace Unit4.Automation.Commands.BcrCommand
                     config, 
                     new JsonFile<Bcr>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "bcr.json")),
                     new JsonFile<SerializableCostCentreList>(Path.Combine(Directory.GetCurrentDirectory(), "cache", "costCentres.json")),
-                    new Unit4EngineFactory(config));
+                    factory,
+                    new CostCentresProvider(config, factory));
             var filter = new BcrFilter(options);
             var writer = new Excel();
             var pathProvider = new PathProvider(options);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -73,7 +73,7 @@ namespace Unit4.Automation.Commands.BcrCommand
         public static BcrReportRunner Create(BcrOptions bcrOptions, ProgramConfig config)
         { 
             var log = new Logging();
-            var reader = new BcrReader(log, config);
+            var reader = new BcrReader(log, bcrOptions, config);
             var filter = new BcrFilter(bcrOptions);
             var writer = new Excel();
             var pathProvider = new PathProvider(bcrOptions);

--- a/Unit4/Commands/BcrCommand/BcrReportRunner.cs
+++ b/Unit4/Commands/BcrCommand/BcrReportRunner.cs
@@ -82,7 +82,7 @@ namespace Unit4.Automation.Commands.BcrCommand
                     new JsonFile<Bcr>(Path.Combine(assemblyDirectory, "cache", "bcr.json")),
                     new JsonFile<SerializableCostCentreList>(Path.Combine(assemblyDirectory, "cache", "costCentres.json")),
                     factory,
-                    new CostCentresProvider(config, factory));
+                    new CostCentresProvider(factory));
             var filter = new BcrFilter(options);
             var writer = new Excel();
             var pathProvider = new PathProvider(options);

--- a/Unit4/Commands/BcrCommand/CostCentreExtensions.cs
+++ b/Unit4/Commands/BcrCommand/CostCentreExtensions.cs
@@ -1,0 +1,35 @@
+using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Unit4.Automation.Commands.BcrCommand
+{
+    internal static class CostCentreExtensions
+    {
+        public static bool Matches(this CostCentre costCentre, BcrOptions options)
+        {
+            if (!HasOption(options.Tier1) && !HasOption(options.Tier2) && !HasOption(options.Tier3) && !HasOption(options.Tier4) && !HasOption(options.CostCentre))
+            {
+                return true;
+            }
+
+            var matchesTier1 = HasOption(options.Tier1) && Matches(options.Tier1, costCentre.Tier1);
+            var matchesTier2 = HasOption(options.Tier2) && Matches(options.Tier2, costCentre.Tier2);
+            var matchesTier3 = HasOption(options.Tier3) && Matches(options.Tier3, costCentre.Tier3);
+            var matchesTier4 = HasOption(options.Tier4) && Matches(options.Tier4, costCentre.Tier4);
+            var matchesCostCentre = HasOption(options.CostCentre) && Matches(options.CostCentre, costCentre.Code);
+            return matchesTier1 || matchesTier2 || matchesTier3 || matchesTier4 || matchesCostCentre;
+        }
+
+        private static bool HasOption(IEnumerable<string> option)
+        {
+            return option != null && option.Any();
+        }
+
+        private static bool Matches(IEnumerable<string> options, string value)
+        {
+            return options.Any(x => string.Equals(x, value));
+        }
+    }
+}

--- a/Unit4/Commands/BcrCommand/CostCentreExtensions.cs
+++ b/Unit4/Commands/BcrCommand/CostCentreExtensions.cs
@@ -1,5 +1,4 @@
 using Unit4.Automation.Model;
-using Unit4.Automation.Interfaces;
 using System.Linq;
 using System.Collections.Generic;
 

--- a/Unit4/Commands/BcrCommand/CostCentreHierarchy.cs
+++ b/Unit4/Commands/BcrCommand/CostCentreHierarchy.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
-using Unit4.Automation.Commands.BcrCommand;
+using Unit4.Automation;
 
-namespace Unit4.Automation
+namespace Unit4.Automation.Commands.BcrCommand
 {
     internal class CostCentreHierarchy
     {

--- a/Unit4/Commands/BcrCommand/CostCentreHierarchy.cs
+++ b/Unit4/Commands/BcrCommand/CostCentreHierarchy.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
-using Unit4.Automation;
 
 namespace Unit4.Automation.Commands.BcrCommand
 {

--- a/Unit4/CostCentreHierarchy.cs
+++ b/Unit4/CostCentreHierarchy.cs
@@ -9,7 +9,7 @@ namespace Unit4.Automation
     {
         private readonly ICache<SerializableCostCentreList> _costCentres;
 
-        public CostCentreHierarchy(ICache<SerializableCostCentreList> costCentres)
+        public CostCentreHierarchy(ICache<SerializableCostCentreList> costCentres, BcrOptions options)
         {
             _costCentres = costCentres;
         }

--- a/Unit4/CostCentreHierarchy.cs
+++ b/Unit4/CostCentreHierarchy.cs
@@ -2,22 +2,26 @@ using System.Collections.Generic;
 using System.Linq;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
+using Unit4.Automation.Commands.BcrCommand;
 
 namespace Unit4.Automation
 {
     internal class CostCentreHierarchy
     {
         private readonly ICache<SerializableCostCentreList> _costCentres;
+        private readonly BcrOptions _options;
 
         public CostCentreHierarchy(ICache<SerializableCostCentreList> costCentres, BcrOptions options)
         {
             _costCentres = costCentres;
+            _options = options;
         }
 
         public IEnumerable<IGrouping<string, CostCentre>> GetHierarchyByTier3()
         {
             var costCentres = _costCentres.Fetch().CostCentres;
-            return costCentres.GroupBy(x => x.Tier3, x => x);
+            var filteredCostCentres = costCentres.Where(x => x.Matches(_options));
+            return filteredCostCentres.GroupBy(x => x.Tier3, x => x);
         }
     }
 }

--- a/Unit4/CostCentresProvider.cs
+++ b/Unit4/CostCentresProvider.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Linq;
 using Unit4.Automation.Model;
+using Unit4.Automation.Interfaces;
 
 namespace Unit4.Automation
 {

--- a/Unit4/CostCentresProvider.cs
+++ b/Unit4/CostCentresProvider.cs
@@ -9,15 +9,17 @@ namespace Unit4.Automation
     internal class CostCentresProvider : ICostCentresProvider
     {
         private readonly ProgramConfig _config;
+        private readonly IUnit4EngineFactory _factory;
 
-        public CostCentresProvider(ProgramConfig config)
+        public CostCentresProvider(ProgramConfig config, IUnit4EngineFactory factory)
         {
             _config = config;
+            _factory = factory;
         }
 
         private DataSet RunReport(string resql)
         {
-            var engine = new Unit4Engine(_config);
+            var engine = _factory.Create();
             return engine.RunReport(resql);
         }
 

--- a/Unit4/CostCentresProvider.cs
+++ b/Unit4/CostCentresProvider.cs
@@ -6,12 +6,10 @@ namespace Unit4.Automation
 {
     internal class CostCentresProvider : ICostCentresProvider
     {
-        private readonly ProgramConfig _config;
         private readonly IUnit4EngineFactory _factory;
 
-        public CostCentresProvider(ProgramConfig config, IUnit4EngineFactory factory)
+        public CostCentresProvider(IUnit4EngineFactory factory)
         {
-            _config = config;
             _factory = factory;
         }
 

--- a/Unit4/CostCentresProvider.cs
+++ b/Unit4/CostCentresProvider.cs
@@ -1,8 +1,6 @@
 using System.Data;
 using System.Linq;
-using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
-using Unit4.Automation.ReportEngine;
 
 namespace Unit4.Automation
 {

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -22,7 +22,7 @@ namespace Unit4.Automation.Model
                 return false;
             }
 
-            return CostCentre == other.CostCentre &&
+            return CostCentre.Equals(other.CostCentre) &&
                 Account == other.Account &&
                 AccountName == other.AccountName &&
                 Budget == other.Budget &&

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -38,9 +38,9 @@ namespace Unit4.Automation.Model
             unchecked
             {
                 int hash = (int) 2166136261;
-                hash = hash * 16777619 + CostCentre.GetHashCode();
-                hash = hash * 16777619 + Account.GetHashCode();
-                hash = hash * 16777619 + AccountName.GetHashCode();
+                hash = hash * 16777619 + CostCentre?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Account?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + AccountName?.GetHashCode() ?? 0;
                 hash = hash * 16777619 + Budget.GetHashCode();
                 hash = hash * 16777619 + Profile.GetHashCode();
                 hash = hash * 16777619 + Actuals.GetHashCode();

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -38,15 +38,15 @@ namespace Unit4.Automation.Model
             unchecked
             {
                 int hash = (int) 2166136261;
-                hash = hash * 16777619 + CostCentre?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Account?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + AccountName?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Budget.GetHashCode();
-                hash = hash * 16777619 + Profile.GetHashCode();
-                hash = hash * 16777619 + Actuals.GetHashCode();
-                hash = hash * 16777619 + Variance.GetHashCode();
-                hash = hash * 16777619 + Forecast.GetHashCode();
-                hash = hash * 16777619 + OutturnVariance.GetHashCode();
+                hash = hash * 16777619 ^ CostCentre?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Account?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ AccountName?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Budget.GetHashCode();
+                hash = hash * 16777619 ^ Profile.GetHashCode();
+                hash = hash * 16777619 ^ Actuals.GetHashCode();
+                hash = hash * 16777619 ^ Variance.GetHashCode();
+                hash = hash * 16777619 ^ Forecast.GetHashCode();
+                hash = hash * 16777619 ^ OutturnVariance.GetHashCode();
                 return hash;
             }
         }

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -13,5 +13,42 @@ namespace Unit4.Automation.Model
         public double Variance { get; set; }
         public double Forecast { get; set; }
         public double OutturnVariance { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as BcrLine;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return CostCentre == other.CostCentre &&
+                Account == other.Account &&
+                AccountName == other.AccountName &&
+                Budget == other.Budget &&
+                Profile == other.Profile &&
+                Actuals == other.Actuals &&
+                Variance == other.Variance &&
+                Forecast == other.Forecast &&
+                OutturnVariance == other.OutturnVariance;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = (int) 2166136261;
+                hash = hash * 16777619 + CostCentre.GetHashCode();
+                hash = hash * 16777619 + Account.GetHashCode();
+                hash = hash * 16777619 + AccountName.GetHashCode();
+                hash = hash * 16777619 + Budget.GetHashCode();
+                hash = hash * 16777619 + Profile.GetHashCode();
+                hash = hash * 16777619 + Actuals.GetHashCode();
+                hash = hash * 16777619 + Variance.GetHashCode();
+                hash = hash * 16777619 + Forecast.GetHashCode();
+                hash = hash * 16777619 + OutturnVariance.GetHashCode();
+                return hash;
+            }
+        }
     }
 }

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -43,8 +43,8 @@ namespace Unit4.Automation.Model
             unchecked
             {
                 int hash = (int) 2166136261;
-                hash = hash * 16777619 + Client.GetHashCode();
-                hash = hash * 16777619 + (Url == null ? 0 : Url.GetHashCode());
+                hash = hash * 16777619 ^ Client.GetHashCode();
+                hash = hash * 16777619 ^ (Url == null ? 0 : Url.GetHashCode());
                 return hash;
             }
         }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -39,16 +39,16 @@ namespace Unit4.Automation.Model
             unchecked
             {
                 int hash = (int) 2166136261;
-                hash = hash * 16777619 + Tier1?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier2?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier3?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier4?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Code?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier1Name?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier2Name?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier3Name?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + Tier4Name?.GetHashCode() ?? 0;
-                hash = hash * 16777619 + CostCentreName?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier1?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier2?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier3?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier4?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Code?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier1Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier2Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier3Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ Tier4Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 ^ CostCentreName?.GetHashCode() ?? 0;
                 return hash;
             }
         }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -39,16 +39,16 @@ namespace Unit4.Automation.Model
             unchecked
             {
                 int hash = (int) 2166136261;
-                hash = hash * 16777619 + Tier1.GetHashCode();
-                hash = hash * 16777619 + Tier2.GetHashCode();
-                hash = hash * 16777619 + Tier3.GetHashCode();
-                hash = hash * 16777619 + Tier4.GetHashCode();
-                hash = hash * 16777619 + Code.GetHashCode();
-                hash = hash * 16777619 + Tier1Name.GetHashCode();
-                hash = hash * 16777619 + Tier2Name.GetHashCode();
-                hash = hash * 16777619 + Tier3Name.GetHashCode();
-                hash = hash * 16777619 + Tier4Name.GetHashCode();
-                hash = hash * 16777619 + CostCentreName.GetHashCode();
+                hash = hash * 16777619 + Tier1?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier2?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier3?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier4?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Code?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier1Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier2Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier3Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + Tier4Name?.GetHashCode() ?? 0;
+                hash = hash * 16777619 + CostCentreName?.GetHashCode() ?? 0;
                 return hash;
             }
         }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -52,6 +52,5 @@ namespace Unit4.Automation.Model
                 return hash;
             }
         }
-
     }
 }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -13,5 +13,45 @@ namespace Unit4.Automation.Model
         public string Tier3Name { get; set; }
         public string Tier4Name { get; set; }
         public string CostCentreName { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as CostCentre;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return Tier1 == other.Tier1 &&
+                Tier2 == other.Tier2 &&
+                Tier3 == other.Tier3 &&
+                Tier4 == other.Tier4 &&
+                Code == other.Code &&
+                Tier1Name == other.Tier1Name &&
+                Tier2Name == other.Tier2Name &&
+                Tier3Name == other.Tier3Name &&
+                Tier4Name == other.Tier4Name &&
+                CostCentreName == other.CostCentreName;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = (int) 2166136261;
+                hash = hash * 16777619 + Tier1.GetHashCode();
+                hash = hash * 16777619 + Tier2.GetHashCode();
+                hash = hash * 16777619 + Tier3.GetHashCode();
+                hash = hash * 16777619 + Tier4.GetHashCode();
+                hash = hash * 16777619 + Code.GetHashCode();
+                hash = hash * 16777619 + Tier1Name.GetHashCode();
+                hash = hash * 16777619 + Tier2Name.GetHashCode();
+                hash = hash * 16777619 + Tier3Name.GetHashCode();
+                hash = hash * 16777619 + Tier4Name.GetHashCode();
+                hash = hash * 16777619 + CostCentreName.GetHashCode();
+                return hash;
+            }
+        }
+
     }
 }

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -76,7 +76,7 @@
     <Compile Include="Model\BcrLine.cs" />
     <Compile Include="ReportEngine\Logging.cs" />
     <Compile Include="CostCentresProvider.cs" />
-    <Compile Include="CostCentreHierarchy.cs" />
+    <Compile Include="Commands\BcrCommand\CostCentreHierarchy.cs" />
     <Compile Include="Model\CostCentre.cs" />
     <Compile Include="Model\Bcr.cs" />
     <Compile Include="Model\SerializableCostCentreList.cs" />

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Commands\BcrCommand\BcrReport.cs" />
     <Compile Include="Commands\BcrCommand\BcrReportRunner.cs" />
     <Compile Include="Commands\BcrCommand\Report.cs" />
+    <Compile Include="Commands\BcrCommand\CostCentreExtensions.cs" />
     <Compile Include="ReportRunnerFactory.cs" />
     <Compile Include="Cache.cs" />
     <Compile Include="JsonFile.cs" />


### PR DESCRIPTION
This changes how we fetch data.

We now:
- look at the options to decide which tier3s are needed
- look in the cache to see if we already have at least one row for every cost centre in that tier3
- fetch any tier3s where we don't have at least one row
- update the cache and results with new data plus data in the cache which we haven't fetched anything for