### PR TITLE
Set the version from the build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,13 @@ script:
 - chmod 754 ./unit4-automation.msi
 addons:
   apt:
-    packages: wine winetricks
+    sources:
+      - sourceline: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main"
+        key_url: "https://packages.microsoft.com/keys/microsoft.asc"
+    packages:
+      - wine
+      - winetricks
+      - powershell
 deploy:
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ solution: "./Unit4.sln"
 install:
 - nuget restore ./Unit4.sln
 script:
+- pwsh -f ./version.ps1
 - msbuild /p:Configuration=Debug ./Unit4.sln
 - mono ./packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe ./Unit4.Automation.Tests/bin/Debug/Unit4.Automation.Tests.dll
   --where="cat != RequiresExcelInstall"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ deploy:
   api_key:
     secure: rrXYBeKiNDIbTFnVFGuv64+vkUUSdmuihks88EaGA/HMa/vhfKaxrVAYA10vPOhOgVCud0pGrVV+XSwD//vbypczkjHCPSZW0d1/44oImTacXDb7hptkJCqbmCOD/MEaf8uoTqhVvLcSpJ7y01axMInWgPnSVAvUlitMANrklCP4FCrX+V8MxFUAwWYolIT4z+1ZBUrt1XjVBXuNVEvSYDm78lRt5rd5BwtSYDSBFOi62616FGNps5hvjW3gACBVndXzit1dTHAurUifFRAZxkwBNkpOFLf6T/lRz5VZ77NmcFyXAVfVb9HofCEJE19rr3AYCgsJ2HBM9Fn8GpLEE79XqAvpveuDiWtheOrWg+waWSeGlbP1dtpxXx6Bfghh+vzlhgy2jfW8w/IbSUyP1vUngIw4tUru6WP7p87QXXGrF/IQrZ6+HJ111G/C72cGFRPFcQR6iaQJvn52YzBJNSkRFjM4RuKxi6WEESe2bQNWLDzVcyEOLsTrBlli5okk1NjujV74h75ASRQuWDqx4doQnoGpJB9ysNAKAvCzamogWEnm5qXzPu1w5X6PKhMVAVWoEcr/Ibjqt0DwR66zDB5kd0Nts0UfPdYXQaHRJ9UBSGc5f2fRqfUDb2RkUCKyVXJd8z4mfUwDZzKEsl5LkcDFvlUbVIQXTDBdrdtOkLA=
   file: unit4-automation.msi
-  name: $TRAVIS_TAG
+  name: $UNIT4_AUTOMATION_VERSION
   on:
     tags: true
     repo: tomcsmith1990/unit4-automation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+env:
+  - UNIT4_AUTOMATION_VERSION="1.0.1"
 solution: "./Unit4.sln"
 install:
 - nuget restore ./Unit4.sln
@@ -27,7 +29,7 @@ deploy:
   api_key:
     secure: rrXYBeKiNDIbTFnVFGuv64+vkUUSdmuihks88EaGA/HMa/vhfKaxrVAYA10vPOhOgVCud0pGrVV+XSwD//vbypczkjHCPSZW0d1/44oImTacXDb7hptkJCqbmCOD/MEaf8uoTqhVvLcSpJ7y01axMInWgPnSVAvUlitMANrklCP4FCrX+V8MxFUAwWYolIT4z+1ZBUrt1XjVBXuNVEvSYDm78lRt5rd5BwtSYDSBFOi62616FGNps5hvjW3gACBVndXzit1dTHAurUifFRAZxkwBNkpOFLf6T/lRz5VZ77NmcFyXAVfVb9HofCEJE19rr3AYCgsJ2HBM9Fn8GpLEE79XqAvpveuDiWtheOrWg+waWSeGlbP1dtpxXx6Bfghh+vzlhgy2jfW8w/IbSUyP1vUngIw4tUru6WP7p87QXXGrF/IQrZ6+HJ111G/C72cGFRPFcQR6iaQJvn52YzBJNSkRFjM4RuKxi6WEESe2bQNWLDzVcyEOLsTrBlli5okk1NjujV74h75ASRQuWDqx4doQnoGpJB9ysNAKAvCzamogWEnm5qXzPu1w5X6PKhMVAVWoEcr/Ibjqt0DwR66zDB5kd0Nts0UfPdYXQaHRJ9UBSGc5f2fRqfUDb2RkUCKyVXJd8z4mfUwDZzKEsl5LkcDFvlUbVIQXTDBdrdtOkLA=
   file: unit4-automation.msi
-  name: $UNIT4_AUTOMATION_VERSION
+  name: ${UNIT4_AUTOMATION_VERSION}
   on:
     tags: true
     repo: tomcsmith1990/unit4-automation

--- a/unit4-automation.wxs
+++ b/unit4-automation.wxs
@@ -6,7 +6,7 @@
     <Product
         Name="Unit4 Automation"
         Manufacturer="Tom Smith"
-        Id="5B9D4119-8874-4573-A5D6-958F45C713E6" 
+        Id="*" 
         UpgradeCode="25340577-2567-4EE3-8619-36EC6A10FA79"
         Language="1033"
         Codepage="1252"

--- a/unit4-automation.wxs
+++ b/unit4-automation.wxs
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+    <?define ProductVersion="1.0.0"?>
+
     <Product
         Name="Unit4 Automation"
         Manufacturer="Tom Smith"
@@ -7,7 +10,7 @@
         UpgradeCode="25340577-2567-4EE3-8619-36EC6A10FA79"
         Language="1033"
         Codepage="1252"
-        Version="1.0.0">
+        Version="$(var.ProductVersion)">
         <Package 
             Id="*"
             Keywords="Installer"

--- a/version.ps1
+++ b/version.ps1
@@ -12,8 +12,10 @@ function Set-Version ([string] $version) {
     $build = if (Test-Path env:TRAVIS_BUILD_NUMBER) { $env:TRAVIS_BUILD_NUMBER } else { 0 }
     
     $assemblyVersion = "$version.$build"
-
+    
     Get-ChildItem -Path AssemblyInfo.cs -Recurse | ForEach-Object { Update-Version $assemblyVersion $_ }
+
+    $env:UNIT4_AUTOMATION_VERSION = $version
 }
 
 Set-Version "1.0.0"

--- a/version.ps1
+++ b/version.ps1
@@ -8,14 +8,13 @@ function Update-Version([string] $version, [string] $assemblyInfoPath) {
     Move-Item $tmpFile $assemblyInfoPath -Force
 }
 
-function Set-Version ([string] $version) {
+function Set-Version () {
+    $version = if (Test-Path env:UNIT4_AUTOMATION_VERSION) { $env:UNIT4_AUTOMATION_VERSION } else { "1.0.0" }
     $build = if (Test-Path env:TRAVIS_BUILD_NUMBER) { $env:TRAVIS_BUILD_NUMBER } else { 0 }
     
     $assemblyVersion = "$version.$build"
     
     Get-ChildItem -Path AssemblyInfo.cs -Recurse | ForEach-Object { Update-Version $assemblyVersion $_ }
-
-    $env:UNIT4_AUTOMATION_VERSION = $version
 }
 
-Set-Version "1.0.1"
+Set-Version

--- a/version.ps1
+++ b/version.ps1
@@ -1,0 +1,16 @@
+function Update-Build([int] $build, [string] $assemblyInfoPath) {
+    $tmpFile = "AssemblyInfo.cs"
+
+    Get-Content $assemblyInfoPath | 
+    %{ $_ -replace "(Assembly.*Version)\(""([0-9]+).([0-9]+).([0-9]+).[0-9]+""\)", "`$1(""`$2.`$3.`$4.$build"")" } |
+    Set-Content $tmpFile
+
+    Move-Item $tmpFile $assemblyInfoPath -Force
+}
+
+function Set-Build {
+    $build = $env:TRAVIS_BUILD_NUMBER
+    Get-ChildItem -Path AssemblyInfo.cs -Recurse | ForEach-Object { Update-Build $build $_ }
+}
+
+Set-Build

--- a/version.ps1
+++ b/version.ps1
@@ -8,6 +8,18 @@ function Update-Version([string] $version, [string] $assemblyInfoPath) {
     Move-Item $tmpFile $assemblyInfoPath -Force
 }
 
+function Update-InstallerVersion([string] $version) {
+    $tmpFile = "installer.wxs"
+
+    $path = ".\unit4-automation.wxs"
+
+    Get-Content $path | 
+    % { $_ -replace "\<\?define ProductVersion=""1.0.0""\?\>", "<?define ProductVersion=""$version""?>" } |
+    Set-Content $tmpFile
+
+    Move-Item $tmpFile $path -Force
+}
+
 function Set-Version () {
     $version = if (Test-Path env:UNIT4_AUTOMATION_VERSION) { $env:UNIT4_AUTOMATION_VERSION } else { "1.0.0" }
     $build = if (Test-Path env:TRAVIS_BUILD_NUMBER) { $env:TRAVIS_BUILD_NUMBER } else { 0 }
@@ -15,6 +27,8 @@ function Set-Version () {
     $assemblyVersion = "$version.$build"
     
     Get-ChildItem -Path AssemblyInfo.cs -Recurse | ForEach-Object { Update-Version $assemblyVersion $_ }
+
+    Update-InstallerVersion $version
 }
 
 Set-Version

--- a/version.ps1
+++ b/version.ps1
@@ -18,4 +18,4 @@ function Set-Version ([string] $version) {
     $env:UNIT4_AUTOMATION_VERSION = $version
 }
 
-Set-Version "1.0.0"
+Set-Version "1.0.1"

--- a/version.ps1
+++ b/version.ps1
@@ -1,16 +1,19 @@
-function Update-Build([int] $build, [string] $assemblyInfoPath) {
+function Update-Version([string] $version, [string] $assemblyInfoPath) {
     $tmpFile = "AssemblyInfo.cs"
 
     Get-Content $assemblyInfoPath | 
-    %{ $_ -replace "(Assembly.*Version)\(""([0-9]+).([0-9]+).([0-9]+).[0-9]+""\)", "`$1(""`$2.`$3.`$4.$build"")" } |
+    %{ $_ -replace "(Assembly.*Version)\(""[0-9]+.[0-9]+.[0-9]+.[0-9]+""\)", "`$1(""$version"")" } |
     Set-Content $tmpFile
 
     Move-Item $tmpFile $assemblyInfoPath -Force
 }
 
-function Set-Build {
-    $build = $env:TRAVIS_BUILD_NUMBER
-    Get-ChildItem -Path AssemblyInfo.cs -Recurse | ForEach-Object { Update-Build $build $_ }
+function Set-Version ([string] $version) {
+    $build = if (Test-Path env:TRAVIS_BUILD_NUMBER) { $env:TRAVIS_BUILD_NUMBER } else { 0 }
+    
+    $assemblyVersion = "$version.$build"
+
+    Get-ChildItem -Path AssemblyInfo.cs -Recurse | ForEach-Object { Update-Version $assemblyVersion $_ }
 }
 
-Set-Build
+Set-Version "1.0.0"


### PR DESCRIPTION
Uses a version (defined) and the build number to set the full version number on the assemblies and installer.

Auto-generate product code so that we can upgrade over old versions.

Upgrade tested manually.