### PR TITLE
Sort the bcr lines by cost centre codes then account

### DIFF
--- a/Unit4.Automation.Tests/BcrFilterTests.cs
+++ b/Unit4.Automation.Tests/BcrFilterTests.cs
@@ -98,5 +98,15 @@ namespace Unit4.Automation.Tests
 
             Assert.That(filter.Use(bcr).Lines.ToList(), Is.Empty);
         }
+
+        [Test]
+        public void GivenTwoLines_ThenTheyShouldBeSorted()
+        {
+            var bcr = new Bcr(new BcrLine[] { A.BcrLine().Account("B"), A.BcrLine().Account("A") });
+
+            var orderedLines = new BcrLine[] { A.BcrLine().Account("A"), A.BcrLine().Account("B") };
+
+            Assert.That(A.BcrFilter().Build().Use(bcr).Lines, Is.EqualTo(orderedLines));
+        }
     }
 }

--- a/Unit4.Automation.Tests/BcrLineTests.cs
+++ b/Unit4.Automation.Tests/BcrLineTests.cs
@@ -23,5 +23,14 @@ namespace Unit4.Automation.Tests
 
             Assert.That(line1, Is.LessThan(line2));
         }
+
+        [Test]
+        public void GivenEqualCostCentre_ThenTheLesserAccountShouldBeUsed()
+        {
+            var line1 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" }, Account = "1" };
+            var line2 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" }, Account = "2" };
+
+            Assert.That(line1, Is.LessThan(line2));
+        }
     }
 }

--- a/Unit4.Automation.Tests/BcrLineTests.cs
+++ b/Unit4.Automation.Tests/BcrLineTests.cs
@@ -16,7 +16,7 @@ namespace Unit4.Automation.Tests
         }
 
         [Test]
-        public void GivenLesserCostCentreThen_TheBcrLineShouldBeLesser()
+        public void GivenLesserCostCentre_ThenTheBcrLineShouldBeLesser()
         {
             var line1 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" } };
             var line2 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "2" } };

--- a/Unit4.Automation.Tests/BcrLineTests.cs
+++ b/Unit4.Automation.Tests/BcrLineTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Unit4.Automation.Model;
+using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests
 {
@@ -15,22 +16,19 @@ namespace Unit4.Automation.Tests
             Assert.That(result, Is.True);
         }
 
-        [Test]
-        public void GivenLesserCostCentre_ThenTheBcrLineShouldBeLesser()
+        [Test, TestCaseSource(nameof(Comparisons))]
+        public void TestBcrLineCompareTo(BcrLine first, BcrLine second)
         {
-            var line1 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" } };
-            var line2 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "2" } };
-
-            Assert.That(line1, Is.LessThan(line2));
+            Assert.That(first, Is.LessThan(second));
         }
 
-        [Test]
-        public void GivenEqualCostCentre_ThenTheLesserAccountShouldBeUsed()
+        private static IEnumerable<TestCaseData> Comparisons
         {
-            var line1 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" }, Account = "1" };
-            var line2 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" }, Account = "2" };
-
-            Assert.That(line1, Is.LessThan(line2));
+            get
+            {
+                yield return new TestCaseData(new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" } }, new BcrLine() { CostCentre = new CostCentre() { Tier1 = "2" } }).SetName("GivenLesserCostCentre_ThenTheBcrLineShouldBeLesser");
+                yield return new TestCaseData(new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" }, Account = "1" }, new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" }, Account = "2" }).SetName("GivenEqualCostCentre_ThenTheLesserAccountShouldBeUsed");
+            }
         }
     }
 }

--- a/Unit4.Automation.Tests/BcrLineTests.cs
+++ b/Unit4.Automation.Tests/BcrLineTests.cs
@@ -14,5 +14,14 @@ namespace Unit4.Automation.Tests
 
             Assert.That(result, Is.True);
         }
+
+        [Test]
+        public void GivenLesserCostCentreThen_TheBcrLineShouldBeLesser()
+        {
+            var line1 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "1" } };
+            var line2 = new BcrLine() { CostCentre = new CostCentre() { Tier1 = "2" } };
+
+            Assert.That(line1, Is.LessThan(line2));
+        }
     }
 }

--- a/Unit4.Automation.Tests/BcrLineTests.cs
+++ b/Unit4.Automation.Tests/BcrLineTests.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    internal class BcrLineTests
+    {
+        [Test]
+        public void GivenNullValue_ThenTheObjectShouldBeGreater()
+        {
+            var line = new BcrLine();
+            var result = line.CompareTo(null) > 0;
+
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -32,5 +32,14 @@ namespace Unit4.Automation.Tests
 
             Assert.That(costCentre1, Is.LessThan(costCentre2));
         }
+
+        [Test]
+        public void GivenEqualTier3_ThenCostCentreComparisonShouldUseTier4Comparison()
+        {
+            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1" };
+            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "2" };
+
+            Assert.That(costCentre1, Is.LessThan(costCentre2));
+        }
     }
 }

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -16,6 +16,13 @@ namespace Unit4.Automation.Tests
         }
 
         [Test]
+        public void GivenCostCentresWithNullValues_ThenTheyAreEqual()
+        {
+            var costCentre1 = new CostCentre();
+            Assert.That(new CostCentre(), Is.Not.LessThan(costCentre1).And.Not.GreaterThan(costCentre1));
+        }
+
+        [Test]
         public void CostCentreComparisonShouldUseTier1Comparison()
         {
             var costCentre1 = new CostCentre() { Tier1 = "1" };

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -41,5 +41,14 @@ namespace Unit4.Automation.Tests
 
             Assert.That(costCentre1, Is.LessThan(costCentre2));
         }
+
+        [Test]
+        public void GivenEqualTier4_ThenCostCentreComparisonShouldUseCostCentreComparison()
+        {
+            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1", Code = "1" };
+            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1", Code = "2" };
+
+            Assert.That(costCentre1, Is.LessThan(costCentre2));
+        }
     }
 }

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Unit4.Automation.Model;
+using System.Collections.Generic;
 
 namespace Unit4.Automation.Tests
 {
@@ -22,49 +23,22 @@ namespace Unit4.Automation.Tests
             Assert.That(new CostCentre(), Is.Not.LessThan(costCentre1).And.Not.GreaterThan(costCentre1));
         }
 
-        [Test]
-        public void CostCentreComparisonShouldUseTier1Comparison()
+        [Test, TestCaseSource(nameof(Comparisons))]
+        public void CostCentreComparisonShouldUseTier1Comparison(CostCentre first, CostCentre second)
         {
-            var costCentre1 = new CostCentre() { Tier1 = "1" };
-            var costCentre2 = new CostCentre() { Tier1 = "2" };
-
-            Assert.That(costCentre1, Is.LessThan(costCentre2));
+            Assert.That(first, Is.LessThan(second));
         }
 
-        [Test]
-        public void GivenEqualTier1_ThenCostCentreComparisonShouldUseTier2Comparison()
+        private static IEnumerable<TestCaseData> Comparisons
         {
-            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1" };
-            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "2" };
-
-            Assert.That(costCentre1, Is.LessThan(costCentre2));
-        }
-
-        [Test]
-        public void GivenEqualTier2_ThenCostCentreComparisonShouldUseTier3Comparison()
-        {
-            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1" };
-            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "2" };
-
-            Assert.That(costCentre1, Is.LessThan(costCentre2));
-        }
-
-        [Test]
-        public void GivenEqualTier3_ThenCostCentreComparisonShouldUseTier4Comparison()
-        {
-            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1" };
-            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "2" };
-
-            Assert.That(costCentre1, Is.LessThan(costCentre2));
-        }
-
-        [Test]
-        public void GivenEqualTier4_ThenCostCentreComparisonShouldUseCostCentreComparison()
-        {
-            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1", Code = "1" };
-            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1", Code = "2" };
-
-            Assert.That(costCentre1, Is.LessThan(costCentre2));
+            get
+            {
+                yield return new TestCaseData(new CostCentre() { Tier1 = "1" }, new CostCentre() { Tier1 = "2" }).SetName("GivenLesserTier1_ThenTheCostCentreShouldBeLesser");
+                yield return new TestCaseData(new CostCentre() { Tier1 = "1", Tier2 = "1" }, new CostCentre() { Tier1 = "1", Tier2 = "2" }).SetName("GivenEqualTier1_ThenLesserTier2ShouldBeUsed");
+                yield return new TestCaseData(new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1" }, new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "2" }).SetName("GivenEqualTier2_ThenLesserTier3ShouldBeUsed");
+                yield return new TestCaseData(new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1" }, new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "2" }).SetName("GivenEqualTier3_ThenLesserTier4ShouldBeUsed");
+                yield return new TestCaseData(new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1", Code = "1" }, new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1", Tier4 = "1", Code = "2" }).SetName("GivenEqualTier4_ThenLesserCostCentreShouldBeUsed");
+            }
         }
     }
 }

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -7,6 +7,15 @@ namespace Unit4.Automation.Tests
     internal class CostCentreTests
     {
         [Test]
+        public void GivenNullValue_ThenTheCostCentreShouldBeGreater()
+        {
+            var costCentre1 = new CostCentre() { Tier1 = "1" };
+            var result = costCentre1.CompareTo(null) > 0;
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
         public void CostCentreComparisonShouldUseTier1Comparison()
         {
             var costCentre1 = new CostCentre() { Tier1 = "1" };

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using Unit4.Automation.Model;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    internal class CostCentreTests
+    {
+        [Test]
+        public void CostCentreComparisonShouldUseTier1Comparison()
+        {
+            var costCentre1 = new CostCentre() { Tier1 = "1" };
+            var costCentre2 = new CostCentre() { Tier1 = "2" };
+
+            Assert.That(costCentre1, Is.LessThan(costCentre2));
+        }
+    }
+}

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -14,5 +14,14 @@ namespace Unit4.Automation.Tests
 
             Assert.That(costCentre1, Is.LessThan(costCentre2));
         }
+
+        [Test]
+        public void GivenEqualTier1_ThenCostCentreComparisonShouldUseTier2Comparison()
+        {
+            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1" };
+            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "2" };
+
+            Assert.That(costCentre1, Is.LessThan(costCentre2));
+        }
     }
 }

--- a/Unit4.Automation.Tests/CostCentreTests.cs
+++ b/Unit4.Automation.Tests/CostCentreTests.cs
@@ -23,5 +23,14 @@ namespace Unit4.Automation.Tests
 
             Assert.That(costCentre1, Is.LessThan(costCentre2));
         }
+
+        [Test]
+        public void GivenEqualTier2_ThenCostCentreComparisonShouldUseTier3Comparison()
+        {
+            var costCentre1 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "1" };
+            var costCentre2 = new CostCentre() { Tier1 = "1", Tier2 = "1", Tier3 = "2" };
+
+            Assert.That(costCentre1, Is.LessThan(costCentre2));
+        }
     }
 }

--- a/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
+++ b/Unit4.Automation.Tests/Helpers/BcrLineBuilder.cs
@@ -11,6 +11,7 @@ namespace Unit4.Automation.Tests.Helpers
         private string _tier3;
         private string _tier4;
         private string _costCentre;
+        private string _account;
 
         private double _actuals;
         
@@ -26,6 +27,12 @@ namespace Unit4.Automation.Tests.Helpers
                 default: throw new NotSupportedException(criteria.ToString());
             }
 
+            return this;
+        }
+
+        public BcrLineBuilder Account(string account)
+        {
+            _account = account;
             return this;
         }
 
@@ -47,7 +54,7 @@ namespace Unit4.Automation.Tests.Helpers
                     Tier4 = builder._tier4,
                     Code = builder._costCentre,
                 },
-                Account = null,
+                Account = builder._account,
                 AccountName = null,
                 Budget = 0,
                 Profile = 0,

--- a/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
+++ b/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Unit4WebConnectorTests.cs" />
     <Compile Include="ExcelTests.cs" />
     <Compile Include="CostCentreHierarchyTests.cs" />
+    <Compile Include="CostCentreTests.cs" />
     <Compile Include="BcrReportTests.cs" />
     <Compile Include="BcrReaderTests.cs" />
     <Compile Include="ConfigRunnerTests.cs" />

--- a/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
+++ b/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ExcelTests.cs" />
     <Compile Include="CostCentreHierarchyTests.cs" />
     <Compile Include="CostCentreTests.cs" />
+    <Compile Include="BcrLineTests.cs" />
     <Compile Include="BcrReportTests.cs" />
     <Compile Include="BcrReaderTests.cs" />
     <Compile Include="ConfigRunnerTests.cs" />

--- a/Unit4/Commands/BcrCommand/BcrFilter.cs
+++ b/Unit4/Commands/BcrCommand/BcrFilter.cs
@@ -16,7 +16,7 @@ namespace Unit4.Automation.Commands.BcrCommand
 
         public Bcr Use(Bcr bcr)
         {
-            return new Bcr(bcr.Lines.Where(x => Matches(x.CostCentre)).ToList());
+            return new Bcr(bcr.Lines.Where(x => Matches(x.CostCentre)).OrderBy(x => x).ToList());
         }
 
         private bool Matches(CostCentre costCentre)

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -18,7 +18,11 @@ namespace Unit4.Automation.Model
         {
             if (other == null) return 1;
 
-            return CostCentre.NullSafeCompareTo(other.CostCentre);
+            var result = 0;
+            if (result == 0) result = CostCentre.NullSafeCompareTo(other.CostCentre);
+            if (result == 0) result = Account.NullSafeCompareTo(other.Account);
+
+            return result;
         }
 
         public override bool Equals(object obj)

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -18,7 +18,7 @@ namespace Unit4.Automation.Model
         {
             if (other == null) return 1;
 
-            return 0;
+            return CostCentre.NullSafeCompareTo(other.CostCentre);
         }
 
         public override bool Equals(object obj)

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -1,6 +1,6 @@
 namespace Unit4.Automation.Model
 {
-    internal class BcrLine
+    internal class BcrLine : System.IComparable<BcrLine>
     {
         public CostCentre CostCentre { get; set; }
         
@@ -14,6 +14,11 @@ namespace Unit4.Automation.Model
         public double Forecast { get; set; }
         public double OutturnVariance { get; set; }
 
+        public int CompareTo(BcrLine other)
+        {
+            return 0;
+        }
+        
         public override bool Equals(object obj)
         {
             var other = obj as BcrLine;

--- a/Unit4/Model/BcrLine.cs
+++ b/Unit4/Model/BcrLine.cs
@@ -16,9 +16,11 @@ namespace Unit4.Automation.Model
 
         public int CompareTo(BcrLine other)
         {
+            if (other == null) return 1;
+
             return 0;
         }
-        
+
         public override bool Equals(object obj)
         {
             var other = obj as BcrLine;

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -19,11 +19,11 @@ namespace Unit4.Automation.Model
             if (other == null) return 1;
 
             var result = 0;
-            if (result == 0) result = Tier1.NullSafeCompareTo(other?.Tier1);
-            if (result == 0) result = Tier2.NullSafeCompareTo(other?.Tier2);
-            if (result == 0) result = Tier3.NullSafeCompareTo(other?.Tier3);
-            if (result == 0) result = Tier4.NullSafeCompareTo(other?.Tier4);
-            if (result == 0) result = Code.NullSafeCompareTo(other?.Code);
+            if (result == 0) result = Tier1.NullSafeCompareTo(other.Tier1);
+            if (result == 0) result = Tier2.NullSafeCompareTo(other.Tier2);
+            if (result == 0) result = Tier3.NullSafeCompareTo(other.Tier3);
+            if (result == 0) result = Tier4.NullSafeCompareTo(other.Tier4);
+            if (result == 0) result = Code.NullSafeCompareTo(other.Code);
 
             return result;
         }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -17,15 +17,23 @@ namespace Unit4.Automation.Model
         public int CompareTo(CostCentre other)
         {
             if (other == null) return 1;
-            
+
             var result = 0;
-            if (result == 0) result = Tier1.CompareTo(other.Tier1);
-            if (result == 0) result = Tier2.CompareTo(other.Tier2);
-            if (result == 0) result = Tier3.CompareTo(other.Tier3);
-            if (result == 0) result = Tier4.CompareTo(other.Tier4);
-            if (result == 0) result = Code.CompareTo(other.Code);
+            if (result == 0) result = Compare(Tier1, other?.Tier1);
+            if (result == 0) result = Compare(Tier2, other?.Tier2);
+            if (result == 0) result = Compare(Tier3, other?.Tier3);
+            if (result == 0) result = Compare(Tier4, other?.Tier4);
+            if (result == 0) result = Compare(Code, other?.Code);
 
             return result;
+        }
+
+        private int Compare<T>(T a, T b) where T : System.IComparable<T>
+        {
+            if (a == null && b == null) return 0;
+            if (a == null) return -1;
+            if (b == null) return 1;
+            return a.CompareTo(b);
         }
 
         public override bool Equals(object obj)

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -19,21 +19,13 @@ namespace Unit4.Automation.Model
             if (other == null) return 1;
 
             var result = 0;
-            if (result == 0) result = Compare(Tier1, other?.Tier1);
-            if (result == 0) result = Compare(Tier2, other?.Tier2);
-            if (result == 0) result = Compare(Tier3, other?.Tier3);
-            if (result == 0) result = Compare(Tier4, other?.Tier4);
-            if (result == 0) result = Compare(Code, other?.Code);
+            if (result == 0) result = Tier1.NullSafeCompareTo(other?.Tier1);
+            if (result == 0) result = Tier2.NullSafeCompareTo(other?.Tier2);
+            if (result == 0) result = Tier3.NullSafeCompareTo(other?.Tier3);
+            if (result == 0) result = Tier4.NullSafeCompareTo(other?.Tier4);
+            if (result == 0) result = Code.NullSafeCompareTo(other?.Code);
 
             return result;
-        }
-
-        private int Compare<T>(T a, T b) where T : System.IComparable<T>
-        {
-            if (a == null && b == null) return 0;
-            if (a == null) return -1;
-            if (b == null) return 1;
-            return a.CompareTo(b);
         }
 
         public override bool Equals(object obj)

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -20,6 +20,7 @@ namespace Unit4.Automation.Model
             if (result == 0) result = Tier1.CompareTo(other.Tier1);
             if (result == 0) result = Tier2.CompareTo(other.Tier2);
             if (result == 0) result = Tier3.CompareTo(other.Tier3);
+            if (result == 0) result = Tier4.CompareTo(other.Tier4);
 
             return result;
         }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -1,6 +1,6 @@
 namespace Unit4.Automation.Model
 {
-    internal class CostCentre
+    internal class CostCentre : System.IComparable<CostCentre>
     {
         public string Tier1 { get; set; }
         public string Tier2 { get; set; }
@@ -13,6 +13,11 @@ namespace Unit4.Automation.Model
         public string Tier3Name { get; set; }
         public string Tier4Name { get; set; }
         public string CostCentreName { get; set; }
+
+        public int CompareTo(CostCentre other)
+        {
+            return Tier1.CompareTo(other.Tier1);
+        }
 
         public override bool Equals(object obj)
         {

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -16,10 +16,12 @@ namespace Unit4.Automation.Model
 
         public int CompareTo(CostCentre other)
         {
-            var tier1 = Tier1.CompareTo(other.Tier1);
-            if (tier1 != 0) return tier1;
+            var result = 0;
+            if (result == 0) result = Tier1.CompareTo(other.Tier1);
+            if (result == 0) result = Tier2.CompareTo(other.Tier2);
+            if (result == 0) result = Tier3.CompareTo(other.Tier3);
 
-            return Tier2.CompareTo(other.Tier2);
+            return result;
         }
 
         public override bool Equals(object obj)

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -21,6 +21,7 @@ namespace Unit4.Automation.Model
             if (result == 0) result = Tier2.CompareTo(other.Tier2);
             if (result == 0) result = Tier3.CompareTo(other.Tier3);
             if (result == 0) result = Tier4.CompareTo(other.Tier4);
+            if (result == 0) result = Code.CompareTo(other.Code);
 
             return result;
         }

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -16,6 +16,8 @@ namespace Unit4.Automation.Model
 
         public int CompareTo(CostCentre other)
         {
+            if (other == null) return 1;
+            
             var result = 0;
             if (result == 0) result = Tier1.CompareTo(other.Tier1);
             if (result == 0) result = Tier2.CompareTo(other.Tier2);

--- a/Unit4/Model/CostCentre.cs
+++ b/Unit4/Model/CostCentre.cs
@@ -16,7 +16,10 @@ namespace Unit4.Automation.Model
 
         public int CompareTo(CostCentre other)
         {
-            return Tier1.CompareTo(other.Tier1);
+            var tier1 = Tier1.CompareTo(other.Tier1);
+            if (tier1 != 0) return tier1;
+
+            return Tier2.CompareTo(other.Tier2);
         }
 
         public override bool Equals(object obj)

--- a/Unit4/Model/ObjectExtensions.cs
+++ b/Unit4/Model/ObjectExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Unit4.Automation.Model
+{
+    internal static class ObjectExtensions
+    {
+        public static int NullSafeCompareTo<T>(this T a, T b) where T : System.IComparable<T>
+        {
+            if (a == null && b == null) return 0;
+            if (a == null) return -1;
+            if (b == null) return 1;
+            return a.CompareTo(b);
+        }
+    }
+}

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Model\NullOptions.cs" />
     <Compile Include="Model\BcrOptions.cs" />
     <Compile Include="Model\ConfigOptions.cs" />
+    <Compile Include="Model\ObjectExtensions.cs" />
     <Compile Include="Model\Credentials.cs" />
     <Compile Include="ReportEngine\Unit4Engine.cs" />
     <Compile Include="ReportEngine\Unit4EngineFactory.cs" />


### PR DESCRIPTION
This implements `IComparable<T>` on `CostCentre` and `BcrLine`, then calls `OrderBy`.

Tests that we call `OrderBy`, and then generally tests the `CompareTo` methods. Haven't tested every combination but it's reasonable coverage.