### PR TITLE
Use MEF to decouple runner from each command

### DIFF
--- a/Unit4.Automation.Tests/OptionsProviderTests.cs
+++ b/Unit4.Automation.Tests/OptionsProviderTests.cs
@@ -3,12 +3,21 @@ using Unit4.Automation;
 using Unit4.Automation.Interfaces;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System;
+using Unit4.Automation.Model;
 
 namespace Unit4.Automation.Tests
 {
     [TestFixture]
     internal class OptionsProviderTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            _options = null;
+        }
+
         [Test]
         public void GivenAnExportOfOptionsInAssembly_ThenItShouldBeLoaded()
         {
@@ -16,6 +25,21 @@ namespace Unit4.Automation.Tests
 
             Assert.That(provider.Types, Is.EqualTo(new[] { typeof(FakeOptions) }));
         }
+
+        [TestCase(typeof(BcrOptions))]
+        [TestCase(typeof(ConfigOptions))]
+        public void GivenAnImportOfOptions_ThenWeShouldLoadTheType(Type type)
+        {
+            var catalog = new AggregateCatalog();
+            catalog.Catalogs.Add(new TypeCatalog(new[] { type }));
+            var container = new CompositionContainer(catalog);
+
+            container.ComposeParts(this);
+
+            Assert.That(_options, Is.TypeOf(type));
+        }
+
+        [Import(typeof(IOptions))] private IOptions _options;
 
         [Export(typeof(IOptions))]
         private class FakeOptions : IOptions

--- a/Unit4.Automation.Tests/OptionsProviderTests.cs
+++ b/Unit4.Automation.Tests/OptionsProviderTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Unit4.Automation;
+using Unit4.Automation.Interfaces;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+
+namespace Unit4.Automation.Tests
+{
+    [TestFixture]
+    internal class OptionsProviderTests
+    {
+        [Test]
+        public void GivenAnExportOfOptionsInAssembly_ThenItShouldBeLoaded()
+        {
+            var provider = new OptionsProvider(GetType().Assembly);
+
+            Assert.That(provider.Types, Is.EqualTo(new[] { typeof(FakeOptions) }));
+        }
+
+        [Export(typeof(IOptions))]
+        private class FakeOptions : IOptions
+        {
+        }
+    }
+}

--- a/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/BcrCommandParserTests.cs
@@ -14,12 +14,12 @@ namespace Unit4.Automation.Tests.Parser
     [TestFixture]
     internal class BcrCommandParserTests
     {
-        private CommandParser<BcrOptions, ConfigOptions> _parser;
+        private CommandParser _parser;
 
         [SetUp]
         public void Setup()
         {
-            _parser = new CommandParser<BcrOptions, ConfigOptions>(TextWriter.Null);
+            _parser = new CommandParser(TextWriter.Null, typeof(BcrOptions));
         }
 
         [Test]

--- a/Unit4.Automation.Tests/Parser/CommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/CommandParserTests.cs
@@ -11,10 +11,10 @@ namespace Unit4.Automation.Tests.Parser
         [SetUp]
         public void Setup()
         {
-            _parser = new CommandParser<BcrOptions, ConfigOptions>(TextWriter.Null);
+            _parser = new CommandParser(TextWriter.Null, typeof(object));
         }
 
-        private CommandParser<BcrOptions, ConfigOptions> _parser;
+        private CommandParser _parser;
 
         [Test]
         public void GivenAnUnknownCommand_ThenTheCommandShouldBeHelp()

--- a/Unit4.Automation.Tests/Parser/ConfigCommandParserTests.cs
+++ b/Unit4.Automation.Tests/Parser/ConfigCommandParserTests.cs
@@ -11,10 +11,10 @@ namespace Unit4.Automation.Tests.Parser
         [SetUp]
         public void Setup()
         {
-            _parser = new CommandParser<BcrOptions, ConfigOptions>(TextWriter.Null);
+            _parser = new CommandParser(TextWriter.Null, typeof(ConfigOptions));
         }
 
-        private CommandParser<BcrOptions, ConfigOptions> _parser;
+        private CommandParser _parser;
 
         [Test]
         public void GivenTheConfigCommand_ThenTheClientOptionShouldBeRecognised()

--- a/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
+++ b/Unit4.Automation.Tests/Unit4.Automation.Tests.csproj
@@ -41,6 +41,8 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Web.Services" />
+    <Reference Include="System.ComponentModel" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="ReportEngine.Base">
       <HintPath>..\lib\ReportEngine.Base.dll</HintPath>
     </Reference>
@@ -104,6 +106,7 @@
     <Compile Include="Parser\CommandParserTests.cs" />
     <Compile Include="SerializableRoundTripTests.cs" />
     <Compile Include="CacheTests.cs" />
+    <Compile Include="OptionsProviderTests.cs" />
     <Compile Include="ReportRunnerFactoryTests.cs" />
     <Compile Include="PathProviderTests.cs" />
     <Compile Include="BcrReportRunnerTests.cs" />

--- a/Unit4/Commands/CommandParser.cs
+++ b/Unit4/Commands/CommandParser.cs
@@ -26,12 +26,19 @@ namespace Unit4.Automation.Commands
 
         public IOptions GetOptions(params string[] args)
         {
-            return _parser
-                .ParseArguments(args, typeof(TVerb), typeof(TVerb2))
-                .MapResult<TVerb, TVerb2, IOptions>(
-                    options => options,
-                    options => options,
-                    errors => new NullOptions());
+            var result = _parser.ParseArguments(args, typeof(TVerb), typeof(TVerb2));
+
+            if (result is NotParsed<object>)
+            {
+                return new NullOptions();
+            }
+
+            if (result is Parsed<object>)
+            {
+                return (result as Parsed<object>).Value as IOptions;
+            }
+            
+            throw new System.Exception();
         }
     }
 }

--- a/Unit4/Commands/CommandParser.cs
+++ b/Unit4/Commands/CommandParser.cs
@@ -3,16 +3,16 @@ using System.IO;
 using CommandLine;
 using Unit4.Automation.Interfaces;
 using Unit4.Automation.Model;
+using System.Linq;
 
 namespace Unit4.Automation.Commands
 {
-    internal class CommandParser<TVerb, TVerb2>
-        where TVerb : IOptions
-        where TVerb2 : IOptions
+    internal class CommandParser
     {
         private readonly Parser _parser;
+        private readonly Type[] _types;
 
-        public CommandParser(TextWriter output)
+        public CommandParser(TextWriter output, params Type[] types)
         {
             _parser = new Parser(
                 settings =>
@@ -22,11 +22,18 @@ namespace Unit4.Automation.Commands
                     settings.MaximumDisplayWidth =
                         Console.WindowWidth > 0 ? Console.WindowWidth : 80; //workaround for tests in Travis
                 });
+
+            _types = types;
         }
 
         public IOptions GetOptions(params string[] args)
         {
-            var result = _parser.ParseArguments(args, typeof(TVerb), typeof(TVerb2));
+            if (!_types.Any())
+            {
+                throw new System.Exception();
+            }
+
+            var result = _parser.ParseArguments(args, _types);
 
             if (result is NotParsed<object>)
             {
@@ -37,7 +44,7 @@ namespace Unit4.Automation.Commands
             {
                 return (result as Parsed<object>).Value as IOptions;
             }
-            
+
             throw new System.Exception();
         }
     }

--- a/Unit4/Model/BcrOptions.cs
+++ b/Unit4/Model/BcrOptions.cs
@@ -2,9 +2,11 @@ using System.Collections.Generic;
 using System.Linq;
 using CommandLine;
 using Unit4.Automation.Interfaces;
+using System.ComponentModel.Composition;
 
 namespace Unit4.Automation.Model
 {
+    [Export(typeof(IOptions))]
     [Verb("bcr", HelpText = "Produce a BCR.")]
     internal class BcrOptions : IOptions
     {

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -1,6 +1,7 @@
 using CommandLine;
 using Unit4.Automation.Interfaces;
 using System.ComponentModel.Composition;
+using Newtonsoft.Json;
 
 namespace Unit4.Automation.Model
 {
@@ -8,8 +9,12 @@ namespace Unit4.Automation.Model
     [Verb("config", HelpText = "Configure the Unit4 connection details.")]
     internal class ConfigOptions : IOptions
     {
-        [ImportingConstructor]
-        public ConfigOptions(int client = 0, string url = null)
+        public ConfigOptions() : this(0, null)
+        {
+        }
+
+        [JsonConstructor]
+        public ConfigOptions(int client, string url)
         {
             Client = client;
             Url = url;

--- a/Unit4/Model/ConfigOptions.cs
+++ b/Unit4/Model/ConfigOptions.cs
@@ -1,11 +1,14 @@
 using CommandLine;
 using Unit4.Automation.Interfaces;
+using System.ComponentModel.Composition;
 
 namespace Unit4.Automation.Model
 {
+    [Export(typeof(IOptions))]
     [Verb("config", HelpText = "Configure the Unit4 connection details.")]
     internal class ConfigOptions : IOptions
     {
+        [ImportingConstructor]
         public ConfigOptions(int client = 0, string url = null)
         {
             Client = client;

--- a/Unit4/OptionsProvider.cs
+++ b/Unit4/OptionsProvider.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Unit4.Automation.Commands;
+using Unit4.Automation.Model;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Collections.Generic;
+using Unit4.Automation.Interfaces;
+using System.Linq;
+
+namespace Unit4.Automation
+{
+    internal class OptionsProvider
+    {
+        [ImportMany(typeof(IOptions))]
+        private IEnumerable<IOptions> _options;
+
+        public OptionsProvider()
+        {
+            var catalog = new AggregateCatalog();
+            catalog.Catalogs.Add(new AssemblyCatalog(typeof(Program).Assembly));
+            var container = new CompositionContainer(catalog);
+
+            try
+            {
+                container.ComposeParts(this);
+            }
+            catch (System.Exception e)
+            {
+                System.Console.WriteLine(e.Message);
+            }
+        }
+
+        public IEnumerable<Type> Types => _options.Select(x => x.GetType());
+    }
+}

--- a/Unit4/OptionsProvider.cs
+++ b/Unit4/OptionsProvider.cs
@@ -12,13 +12,12 @@ namespace Unit4.Automation
 {
     internal class OptionsProvider
     {
-        [ImportMany(typeof(IOptions))]
-        private IEnumerable<IOptions> _options;
+        [ImportMany(typeof(IOptions))] private IEnumerable<IOptions> _options;
 
-        public OptionsProvider()
+        public OptionsProvider(System.Reflection.Assembly assembly)
         {
             var catalog = new AggregateCatalog();
-            catalog.Catalogs.Add(new AssemblyCatalog(typeof(Program).Assembly));
+            catalog.Catalogs.Add(new AssemblyCatalog(assembly));
             var container = new CompositionContainer(catalog);
 
             try

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -14,7 +14,7 @@ namespace Unit4.Automation
     {
         static void Main(string[] args)
         {
-            var provider = new OptionsProvider();
+            var provider = new OptionsProvider(typeof(Program).Assembly);
             var options = new CommandParser(Console.Out, provider.Types.ToArray()).GetOptions(args);
 
             var runner = new ReportRunnerFactory().Create(options);

--- a/Unit4/Program.cs
+++ b/Unit4/Program.cs
@@ -1,6 +1,12 @@
 ﻿using System;
 using Unit4.Automation.Commands;
 using Unit4.Automation.Model;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Collections.Generic;
+using Unit4.Automation.Interfaces;
+using System.Linq;
 
 namespace Unit4.Automation
 {
@@ -8,7 +14,8 @@ namespace Unit4.Automation
     {
         static void Main(string[] args)
         {
-            var options = new CommandParser<BcrOptions, ConfigOptions>(Console.Out).GetOptions(args);
+            var provider = new OptionsProvider();
+            var options = new CommandParser(Console.Out, provider.Types.ToArray()).GetOptions(args);
 
             var runner = new ReportRunnerFactory().Create(options);
 

--- a/Unit4/Unit4.csproj
+++ b/Unit4/Unit4.csproj
@@ -41,6 +41,8 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Web.Services" />
+    <Reference Include="System.ComponentModel" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="ReportEngine.Base">
       <HintPath>..\lib\ReportEngine.Base.dll</HintPath>
     </Reference>
@@ -100,6 +102,7 @@
     <Compile Include="Commands\BcrCommand\Report.cs" />
     <Compile Include="Commands\BcrCommand\CostCentreExtensions.cs" />
     <Compile Include="ReportRunnerFactory.cs" />
+    <Compile Include="OptionsProvider.cs" />
     <Compile Include="Cache.cs" />
     <Compile Include="JsonFile.cs" />
     <Compile Include="Excel.cs" />


### PR DESCRIPTION
At the moment, `Program` has to know about every command we have.

It would probably be cleaner to have each command in its own assembly, so this uses [MEF](https://docs.microsoft.com/en-us/dotnet/framework/mef/) to load implementations of `IOptions`. Currently loading just the ones in this assembly, but we could split them out and load all in the directory.

Tested that:
- the expected options classes can be imported
- the importer loads the right things